### PR TITLE
Disable footer via configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -286,7 +286,7 @@ SHOW_TRY_EASIER=true                              # Show "try easier" section (t
 SHOW_POWERED_BY=true                              # Show powered by (true|false)
 SHOW_SPONSORS=true                                # Show sponsors (true|false)
 SHOW_ADVERTISERS=true                             # Show advertisers (true|false)
-SHOW_FOOTER=true                                  # Show footer (true|false)
+SHOW_FOOTER=false                                 # Show footer (true|false)
 
 # Who Are You
 WHO_ARE_YOU_TITLE="Who are you?"                  # Title

--- a/app/src/config.js
+++ b/app/src/config.js
@@ -41,7 +41,7 @@ config.ui.brand = {
     poweredBy: false,
     sponsors: false,
     advertisers: false,
-    footer: true
+    footer: false
   }
 };
 


### PR DESCRIPTION
## Summary
- disable site footer by default in config and environment template

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abf3969540832bbb0000278694c683