### PR TITLE
Rebrand UI text to Kremlevka

### DIFF
--- a/app/src/HtmlInjector.js
+++ b/app/src/HtmlInjector.js
@@ -22,11 +22,11 @@ class HtmlInjector {
     getInjectData() {
         return {
             OG_TYPE: this.config?.og?.type || 'app-webrtc',
-            OG_SITE_NAME: this.config?.og?.siteName || 'MiroTalk SFU',
+            OG_SITE_NAME: this.config?.og?.siteName || 'Kremlevka',
             OG_TITLE: this.config?.og?.title || 'Click the link to make a call.',
             OG_DESCRIPTION:
                 this.config?.og?.description ||
-                'MiroTalk SFU calling provides real-time video calls, messaging and screen sharing.',
+                'Kremlevka provides real-time video calls, messaging and screen sharing.',
             OG_IMAGE: this.config?.og?.image || 'https://sfu.mirotalk.com/images/mirotalksfu.png',
             OG_URL: this.config?.og?.url || 'https://sfu.mirotalk.com',
             // Add more data here as needed with fallbacks

--- a/app/src/config.template.js
+++ b/app/src/config.template.js
@@ -636,7 +636,7 @@ module.exports = {
             enabled: process.env.VIDEOAI_ENABLED === 'true',
             basePath: 'https://api.heygen.com',
             apiKey: process.env.VIDEOAI_API_KEY || '',
-            systemLimit: process.env.VIDEOAI_SYSTEM_LIMIT || 'You are a streaming avatar from MiroTalk SFU...',
+            systemLimit: process.env.VIDEOAI_SYSTEM_LIMIT || 'You are a streaming avatar from Kremlevka...',
         },
 
         /**
@@ -1035,10 +1035,10 @@ module.exports = {
              */
             og: {
                 type: process.env.OG_TYPE || 'app-webrtc',
-                siteName: process.env.OG_SITE_NAME || 'Spectrum',
+                siteName: process.env.OG_SITE_NAME || 'Kremlevka',
                 title: process.env.OG_TITLE || 'Click the link to make a call.',
                 description:
-                    process.env.OG_DESCRIPTION || 'Spectrum provides real-time video calls and screen sharing.',
+                    process.env.OG_DESCRIPTION || 'Kremlevka provides real-time video calls and screen sharing.',
                 image: process.env.OG_IMAGE_URL || 'https://sfu.mirotalk.com/images/mirotalksfu.png',
                 url: process.env.OG_URL || 'https://sfu.mirotalk.com',
             },
@@ -1148,7 +1148,7 @@ module.exports = {
                         connectText: process.env.WIDGET_SUPPORT_CONNECT_TEXT || 'connect in < 5 seconds',
                         onlineText: process.env.WIDGET_SUPPORT_ONLINE_TEXT || 'We are online',
                         offlineText: process.env.WIDGET_SUPPORT_OFFLINE_TEXT || 'We are offline',
-                        poweredBy: process.env.WIDGET_SUPPORT_POWERED_BY || 'Powered by MiroTalk SFU',
+                        poweredBy: process.env.WIDGET_SUPPORT_POWERED_BY || 'Powered by Kremlevka',
                     },
                 },
                 alert: {

--- a/app/src/lib/nodemailer.js
+++ b/app/src/lib/nodemailer.js
@@ -5,7 +5,7 @@ const config = require('../config');
 const Logger = require('../Logger');
 const log = new Logger('NodeMailer');
 
-const APP_NAME = config.ui.brand.app.name || 'MiroTalk SFU';
+const APP_NAME = config.ui.brand.app.name || 'Kremlevka';
 
 // ####################################################
 // EMAIL CONFIG

--- a/public/js/Brand.js
+++ b/public/js/Brand.js
@@ -36,8 +36,8 @@ const guestJoinRoomButton = document.getElementById('guestJoinRoomButton');
 let BRAND = {
     app: {
         language: 'en',
-        name: 'MiroTalk SFU',
-        title: 'MiroTalk SFU<br />Free browser based Real-time video calls.<br />Simple, Secure, Fast.',
+        name: 'Kremlevka',
+        title: 'Kremlevka<br />Free browser based Real-time video calls.<br />Simple, Secure, Fast.',
         description:
             'Start your next video call with a single click. No download, plug-in, or login is required. Just get straight to talking, messaging, and sharing your screen.',
         joinDescription: 'Pick a room name.<br />How about this one?',
@@ -45,7 +45,7 @@ let BRAND = {
         joinLastLabel: 'Your recent room:',
     },
     site: {
-        title: 'MiroTalk SFU, Free Video Calls, Messaging and Screen Sharing',
+        title: 'Kremlevka, Free Video Calls, Messaging and Screen Sharing',
         icon: '../images/logo.svg',
         appleTouchIcon: '../images/logo.svg',
         newRoomTitle: 'Pick name. <br />Share URL. <br />Start conference.',
@@ -54,7 +54,7 @@ let BRAND = {
     },
     meta: {
         description:
-            'MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser.',
+            'Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser.',
         keywords:
             'webrtc, miro, mediasoup, mediasoup-client, self hosted, voip, sip, real-time communications, chat, messaging, meet, webrtc stun, webrtc turn, webrtc p2p, webrtc sfu, video meeting, video chat, video conference, multi video chat, multi video conference, peer to peer, p2p, sfu, rtc, alternative to, zoom, microsoft teams, google meet, jitsi, meeting',
     },
@@ -98,12 +98,12 @@ let BRAND = {
             <a 
                 id="email-button" 
                 data-umami-event="Email button" 
-                href="mailto:miroslav.pejic.85@gmail.com?subject=MiroTalk SFU info"> 
+                href="mailto:miroslav.pejic.85@gmail.com?subject=Kremlevka info">
                 miroslav.pejic.85@gmail.com
             </a>
             <br /><br />
             <hr />
-            <span>&copy; 2025 MiroTalk SFU, all rights reserved</span>
+            <span>&copy; 2025 Kremlevka, all rights reserved</span>
             <hr />
         `,
     },
@@ -133,7 +133,7 @@ let BRAND = {
                 connectText: 'connect in < 5 seconds',
                 onlineText: 'We are online',
                 offlineText: 'We are offline',
-                poweredBy: 'Powered by MiroTalk SFU',
+                poweredBy: 'Powered by Kremlevka',
             },
             alert: {
                 enabled: false,

--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -3645,7 +3645,7 @@ function leaveFeedback(allowCancel) {
         imageUrl: image.feedback,
         position: 'top',
         title: 'Leave a feedback',
-        text: 'Do you want to rate your MiroTalk experience?',
+        text: 'Do you want to rate your Kremlevka experience?',
         confirmButtonText: `Yes`,
         denyButtonText: `No`,
         cancelButtonText: `Cancel`,
@@ -5560,12 +5560,12 @@ function showAbout() {
                             <a 
                                 id="email-button" 
                                 data-umami-event="Email button" 
-                                href="mailto:miroslav.pejic.85@gmail.com?subject=MiroTalk SFU info"> 
+                                href="mailto:miroslav.pejic.85@gmail.com?subject=Kremlevka info">
                                 miroslav.pejic.85@gmail.com
                             </a>
                             <br /><br />
                             <hr />
-                            <span>&copy; 2025 MiroTalk SFU, all rights reserved</span>
+                            <span>&copy; 2025 Kremlevka, all rights reserved</span>
                             <hr />
                         `
                 }

--- a/public/js/Widget.js
+++ b/public/js/Widget.js
@@ -28,11 +28,11 @@ class MiroTalkWidget {
             customMessages: {
                 heading: 'Need a hand?',
                 subheading:
-                    'Hop on a <span style="font-weight: bold">Free 1:1 or Group Consultation</span> with a MiroTalk Expert right now!',
+                    'Hop on a <span style="font-weight: bold">Free 1:1 or Group Consultation</span> with a Kremlevka Expert right now!',
                 connectText: 'connect in < 10 seconds',
                 onlineText: 'We are online',
                 offlineText: 'We are offline',
-                poweredBy: 'Powered by <span class="mirotalk-powered-by">MiroTalk</span>',
+                poweredBy: 'Powered by <span class="mirotalk-powered-by">Kremlevka</span>',
             },
         },
     };
@@ -789,6 +789,6 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         }
     } catch (error) {
-        console.error('Failed to auto-initialize MiroTalk Widget:', error);
+        console.error('Failed to auto-initialize Kremlevka Widget:', error);
     }
 });

--- a/public/views/404.html
+++ b/public/views/404.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Title and Icon -->
 
-        <title id="title">MiroTalk SFU - 404 Page not found.</title>
+        <title id="title">Kremlevka - 404 Page not found.</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
@@ -16,7 +16,7 @@
         <meta
             id="description"
             name="description"
-            content="MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
         />
         <meta
             id="keywords"
@@ -193,7 +193,7 @@
                                 >
                             </li>
                         </ul>
-                        <div class="footer-copyright">&copy; 2025 MiroTalk SFU, all rights reserved</div>
+                        <div class="footer-copyright">&copy; 2025 Kremlevka, all rights reserved</div>
                     </div>
                 </div>
             </footer>

--- a/public/views/50X.html
+++ b/public/views/50X.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Title and Icon -->
 
-        <title id="title">MiroTalk SFU - 50X Under Maintenance.</title>
+        <title id="title">Kremlevka - 50X Under Maintenance.</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
@@ -16,7 +16,7 @@
         <meta
             id="description"
             name="description"
-            content="MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
         />
         <meta
             id="keywords"
@@ -182,7 +182,7 @@
                                 >
                             </li>
                         </ul>
-                        <div class="footer-copyright">&copy; 2025 MiroTalk SFU, all rights reserved</div>
+                        <div class="footer-copyright">&copy; 2025 Kremlevka, all rights reserved</div>
                     </div>
                 </div>
             </footer>

--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Title and Icon -->
 
-        <title id="title">MiroTalk SFU - Room Video Calls, Messaging and Screen Sharing.</title>
+        <title id="title">Kremlevka - Room Video Calls, Messaging and Screen Sharing.</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
@@ -18,7 +18,7 @@
         <meta
             id="description"
             name="description"
-            content="MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
         />
         <meta
             id="keywords"

--- a/public/views/RtmpStreamer.html
+++ b/public/views/RtmpStreamer.html
@@ -6,7 +6,7 @@
 
         <!-- Title and Icon -->
 
-        <title id="title">MiroTalk RTMP Streamer</title>
+        <title id="title">Kremlevka RTMP Streamer</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
@@ -19,7 +19,7 @@
         <meta
             id="description"
             name="description"
-            content="MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
         />
         <meta
             id="keywords"
@@ -90,7 +90,7 @@
             </div>
         </div>
         <footer id="footer">
-            <p>&copy; 2025 MiroTalk SFU, all rights reserved</p>
+            <p>&copy; 2025 Kremlevka, all rights reserved</p>
         </footer>
     </body>
 </html>

--- a/public/views/about.html
+++ b/public/views/about.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Title and Icon -->
 
-        <title id="title">MiroTalk SFU - About.</title>
+        <title id="title">Kremlevka - About.</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
@@ -16,7 +16,7 @@
         <meta
             id="description"
             name="description"
-            content="MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
         />
         <meta
             id="keywords"
@@ -137,7 +137,7 @@
                             >
                         </li>
                     </ul>
-                    <div class="footer-copyright">&copy; 2025 MiroTalk SFU, all rights reserved</div>
+                    <div class="footer-copyright">&copy; 2025 Kremlevka, all rights reserved</div>
                 </div>
             </div>
         </footer>

--- a/public/views/activeRooms.html
+++ b/public/views/activeRooms.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <title id="title">MiroTalk SFU - Active Rooms.</title>
+        <title id="title">Kremlevka - Active Rooms.</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 

--- a/public/views/iframe.html
+++ b/public/views/iframe.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>MiroTalk SFU Iframe demo</title>
+        <title>Kremlevka Iframe demo</title>
 
         <!-- Replace sfu.mirotalk.com with YOUR-DOMAIN-NAME -->
         <script src="https://sfu.mirotalk.com/js/Iframe.js" defer></script>

--- a/public/views/landing.html
+++ b/public/views/landing.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Title and Icon -->
 
-        <title id="title">MiroTalk SFU, Free Video Calls, Messaging and Screen Sharing</title>
+        <title id="title">Kremlevka, Free Video Calls, Messaging and Screen Sharing</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
@@ -16,7 +16,7 @@
         <meta
             id="description"
             name="description"
-            content="MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
         />
         <meta
             id="keywords"

--- a/public/views/login.html
+++ b/public/views/login.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Title and Icon -->
 
-        <title id="title">MiroTalk SFU - Host Protected login required.</title>
+        <title id="title">Kremlevka - Host Protected login required.</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
@@ -16,7 +16,7 @@
         <meta
             id="description"
             name="description"
-            content="MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
         />
         <meta
             id="keywords"
@@ -261,7 +261,7 @@
                                 >
                             </li>
                         </ul>
-                        <div class="footer-copyright">&copy; 2025 MiroTalk SFU, all rights reserved</div>
+                        <div class="footer-copyright">&copy; 2025 Kremlevka, all rights reserved</div>
                     </div>
                 </div>
             </footer>

--- a/public/views/maintenance.html
+++ b/public/views/maintenance.html
@@ -55,7 +55,7 @@
                     shortly!
                 </p>
                 <img src="https://media.giphy.com/media/dWesBcTLavkZuG35MI/giphy.gif" />
-                <p>&mdash; The MiroTalk Team</p>
+                <p>&mdash; The Kremlevka Team</p>
             </div>
         </article>
     </body>

--- a/public/views/newroom.html
+++ b/public/views/newroom.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Title and Icon -->
 
-        <title id="title">MiroTalk SFU - Create your Room name and start the new call.</title>
+        <title id="title">Kremlevka - Create your Room name and start the new call.</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
@@ -16,7 +16,7 @@
         <meta
             id="description"
             name="description"
-            content="MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
         />
         <meta
             id="keywords"
@@ -235,7 +235,7 @@
                                 >
                             </li>
                         </ul>
-                        <div class="footer-copyright">&copy; 2025 MiroTalk SFU, all rights reserved</div>
+                        <div class="footer-copyright">&copy; 2025 Kremlevka, all rights reserved</div>
                     </div>
                 </div>
             </footer>

--- a/public/views/permission.html
+++ b/public/views/permission.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Title and Icon -->
 
-        <title id="title">MiroTalk SFU - Allow Video or Audio access to join in the Room.</title>
+        <title id="title">Kremlevka - Allow Video or Audio access to join in the Room.</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
@@ -16,7 +16,7 @@
         <meta
             id="description"
             name="description"
-            content="MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
         />
         <meta
             id="keywords"
@@ -198,7 +198,7 @@
                                 >
                             </li>
                         </ul>
-                        <div class="footer-copyright">&copy; 2025 MiroTalk SFU, all rights reserved</div>
+                        <div class="footer-copyright">&copy; 2025 Kremlevka, all rights reserved</div>
                     </div>
                 </div>
             </footer>

--- a/public/views/privacy.html
+++ b/public/views/privacy.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Title and Icon -->
 
-        <title id="title">MiroTalk SFU - privacy policy.</title>
+        <title id="title">Kremlevka - privacy policy.</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
@@ -16,7 +16,7 @@
         <meta
             id="description"
             name="description"
-            content="MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
         />
         <meta
             id="keywords"
@@ -72,7 +72,7 @@
                                 <h1 class="hero-title mt-0">Privacy Policy</h1>
                                 <p class="hero-paragraph" id="message"></p>
                                 <p class="hero-paragraph">
-                                    <strong>MiroTalk SFU</strong> has an integrated
+                                    <strong>Kremlevka</strong> has an integrated
                                     <a href="https://mediasoup.org/" target="_blank">mediasoup server</a>. Routing is a
                                     multiparty topology, where each participant sends its media to this server and
                                     receives all other's media from it. Thanks to the SFU architecture, it allows having
@@ -85,7 +85,7 @@
                                     >, then will be downloaded on Your PC/Mobile Device.<br /><br />
                                     We use Umami to track aggregated usage statistics in order to improve our service.
                                     The maker of
-                                    <strong>MiroTalk SFU</strong> has no intention of using personally or selling any of
+                                    <strong>Kremlevka</strong> has no intention of using personally or selling any of
                                     the above-mentioned data.
                                 </p>
                                 <div>
@@ -201,7 +201,7 @@
                                 >
                             </li>
                         </ul>
-                        <div class="footer-copyright">&copy; 2025 MiroTalk SFU, all rights reserved</div>
+                        <div class="footer-copyright">&copy; 2025 Kremlevka, all rights reserved</div>
                     </div>
                 </div>
             </footer>

--- a/public/views/whoAreYou.html
+++ b/public/views/whoAreYou.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Title and Icon -->
 
-        <title id="title">MiroTalk SFU - Who are you.</title>
+        <title id="title">Kremlevka - Who are you.</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
@@ -16,7 +16,7 @@
         <meta
             id="description"
             name="description"
-            content="MiroTalk SFU powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
         />
         <meta
             id="keywords"
@@ -185,7 +185,7 @@
                                 >
                             </li>
                         </ul>
-                        <div class="footer-copyright">&copy; 2025 MiroTalk SFU, all rights reserved</div>
+                        <div class="footer-copyright">&copy; 2025 Kremlevka, all rights reserved</div>
                     </div>
                 </div>
             </footer>

--- a/rtmpServers/demo/client-server-axios/client/index.html
+++ b/rtmpServers/demo/client-server-axios/client/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>MiroTalk RTMP Streamer</title>
+        <title>Kremlevka RTMP Streamer</title>
         <link id="icon" rel="shortcut icon" href="./logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="./logo.svg" />
         <link rel="stylesheet" href="./style.css" />
@@ -16,7 +16,7 @@
             <button id="closePopup">X</button>
         </div>
         <div class="container">
-            <h1>MiroTalk RTMP Streamer</h1>
+            <h1>Kremlevka RTMP Streamer</h1>
             <div class="input-group-inline">
                 <input
                     id="apiSecret"
@@ -45,7 +45,7 @@
             </div>
         </div>
         <footer>
-            <p>&copy; 2025 MiroTalk SFU, all rights reserved</p>
+            <p>&copy; 2025 Kremlevka, all rights reserved</p>
         </footer>
     </body>
 </html>

--- a/rtmpServers/demo/client-server-socket/client/index.html
+++ b/rtmpServers/demo/client-server-socket/client/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>MiroTalk RTMP Streamer</title>
+        <title>Kremlevka RTMP Streamer</title>
         <link id="icon" rel="shortcut icon" href="./logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="./logo.svg" />
         <link rel="stylesheet" href="./style.css" />
@@ -17,7 +17,7 @@
             <button id="closePopup">X</button>
         </div>
         <div class="container">
-            <h1>MiroTalk RTMP Streamer</h1>
+            <h1>Kremlevka RTMP Streamer</h1>
             <div class="input-group-inline">
                 <input
                     id="apiSecret"
@@ -46,7 +46,7 @@
             </div>
         </div>
         <footer>
-            <p>&copy; 2025 MiroTalk SFU, all rights reserved</p>
+            <p>&copy; 2025 Kremlevka, all rights reserved</p>
         </footer>
     </body>
 </html>

--- a/widgets/README.md
+++ b/widgets/README.md
@@ -1,7 +1,7 @@
-# MiroTalk SFU Widgets
+# Kremlevka Widgets
 
 ![widget](./widget.png)
 
 ---
 
-This directory contains embeddable example widgets for MiroTalk SFU that can be integrated into any website or application.
+This directory contains embeddable example widgets for Kremlevka that can be integrated into any website or application.

--- a/widgets/example-1.html
+++ b/widgets/example-1.html
@@ -21,7 +21,7 @@
             data-connect-text="connect in &lt; 5 seconds"
             data-online-text="We are online"
             data-offline-text="We are offline"
-            data-powered-by="Powered by MiroTalk"
+            data-powered-by="Powered by Kremlevka"
         ></div>
     </body>
 </html>

--- a/widgets/example-2.html
+++ b/widgets/example-2.html
@@ -31,7 +31,7 @@
                                 connectText: 'connect in < 5 seconds',
                                 onlineText: 'We are online',
                                 offlineText: 'We are offline',
-                                poweredBy: 'Powered by MiroTalk SFU',
+                                poweredBy: 'Powered by Kremlevka',
                             },
                         },
                     });

--- a/widgets/example-3.html
+++ b/widgets/example-3.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>MiroTalk SFU - Custom Support Widget</title>
+        <title>Kremlevka - Custom Support Widget</title>
         <style>
             /* Keyframes */
             @keyframes pulse {
@@ -522,7 +522,7 @@
 
             <!-- Subheading -->
             <p class="subheading">
-                Hop on a <span style="font-weight: bold">Free 1:1 or Group Consultation</span> with a MiroTalk Expert
+                Hop on a <span style="font-weight: bold">Free 1:1 or Group Consultation</span> with a Kremlevka Expert
                 right now!
             </p>
 
@@ -582,7 +582,7 @@
             </button>
 
             <div class="footer-text">
-                Powered by <a href="#" class="footer-link" onclick="CallManager.openMiroTalk()">MiroTalk</a>
+                Powered by <a href="#" class="footer-link" onclick="CallManager.openMiroTalk()">Kremlevka</a>
             </div>
         </div>
 
@@ -609,7 +609,7 @@
         <script>
             // Configuration
             const CONFIG = {
-                domain: 'sfu.mirotalk.com', // Replace with your MiroTalk server domain
+                domain: 'sfu.mirotalk.com', // Replace with your Kremlevka server domain
                 roomId: 'test', // Replace with desired room ID
                 userName: 'guest-' + Math.floor(Math.random() * 10000),
                 checkOnlineStatus: false, // Set to true to enable real status checking

--- a/widgets/example-4.html
+++ b/widgets/example-4.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>MiroTalk SFU - Simple Iframe Example</title>
+        <title>Kremlevka - Simple Iframe Example</title>
     </head>
     <body>
         <iframe

--- a/widgets/example-5.html
+++ b/widgets/example-5.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>MiroTalk SFU - Embedded Meeting Widget</title>
+        <title>Kremlevka - Embedded Meeting Widget</title>
 
         <script src="https://sfu.mirotalk.com/js/Iframe.js" defer></script>
 

--- a/widgets/maker.html
+++ b/widgets/maker.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>MiroTalk Widget Maker</title>
+        <title>Kremlevka Widget Maker</title>
         <link
             rel="icon"
             href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>"
@@ -449,7 +449,7 @@
     <body>
         <div class="container">
             <div class="header">
-                <h1>MiroTalk Widget Maker</h1>
+                <h1>Kremlevka Widget Maker</h1>
                 <p>Create custom embeddable widgets for your website in seconds</p>
             </div>
 
@@ -459,7 +459,7 @@
                     <h2>Widget Configuration</h2>
 
                     <div class="form-group">
-                        <label for="domain" class="tooltip" data-tooltip="Your MiroTalk server domain">
+                        <label for="domain" class="tooltip" data-tooltip="Your Kremlevka server domain">
                             Domain <span style="color: #dc3545">*</span>
                         </label>
                         <input
@@ -577,8 +577,8 @@ Get instant support from our expert team!</textarea
                         <input
                             type="text"
                             id="powered-by"
-                            value="Powered by MiroTalk"
-                            placeholder="Powered by MiroTalk"
+                            value="Powered by Kremlevka"
+                            placeholder="Powered by Kremlevka"
                         />
                     </div>
 
@@ -659,7 +659,7 @@ https://i.pravatar.cc/40?img=1,https://i.pravatar.cc/40?img=2,https://i.pravatar
                     connectText: form.connectText.value || 'connect in < 5 seconds',
                     onlineText: form.onlineText.value || 'We are online',
                     offlineText: form.offlineText.value || 'We are offline',
-                    poweredBy: form.poweredBy.value || 'Powered by MiroTalk',
+                    poweredBy: form.poweredBy.value || 'Powered by Kremlevka',
                     expertImages:
                         form.expertImages.value ||
                         'https://i.pravatar.cc/40?img=1,https://i.pravatar.cc/40?img=2,https://i.pravatar.cc/40?img=3',
@@ -679,7 +679,7 @@ https://i.pravatar.cc/40?img=1,https://i.pravatar.cc/40?img=2,https://i.pravatar
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
-<title>MiroTalk Widget</title>
+<title>Kremlevka Widget</title>
 <script src="https://${config.domain}/js/Widget.js"><\/script>
 </head>
 <body>
@@ -760,7 +760,7 @@ https://i.pravatar.cc/40?img=1,https://i.pravatar.cc/40?img=2,https://i.pravatar
                 form.connectText.value = 'connect in < 5 seconds';
                 form.onlineText.value = 'We are online';
                 form.offlineText.value = 'We are offline';
-                form.poweredBy.value = 'Powered by MiroTalk';
+                form.poweredBy.value = 'Powered by Kremlevka';
                 form.expertImages.value =
                     'https://i.pravatar.cc/40?img=1,https://i.pravatar.cc/40?img=2,https://i.pravatar.cc/40?img=3';
                 form.btnAudio.checked =


### PR DESCRIPTION
## Summary
- Replace visible mentions of MiroTalk and Spectrum with Kremlevka across UI configuration and views
- Update widget and demo pages to show Kremlevka branding
- Adjust default config and metadata to reflect Kremlevka

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acb2588fcc832b8f0d520379d2faf6