### PR TITLE
feat: restore hero sections on login and landing pages

### DIFF
--- a/public/views/landing.html
+++ b/public/views/landing.html
@@ -44,6 +44,39 @@
     <body class="is-boxed">
         <div class="body-wrap">
             <main>
+                <section class="hero">
+                    <div class="container">
+                        <div class="hero-inner">
+                            <div class="hero-copy reveal-from-bottom">
+                                <h1 id="newRoomTitle" class="hero-title mt-0">
+                                    Pick name. <br />
+                                    Share URL. <br />
+                                    Start conference.
+                                </h1>
+                                <p id="newRoomDescription" class="hero-paragraph">
+                                    Each room has its disposable URL. Just pick a room name and share your custom URL.
+                                    It's that easy.
+                                </p>
+                            </div>
+                            <div class="hero-figure anime-element">
+                                <svg class="placeholder" width="528" height="396" viewBox="0 0 528 396">
+                                    <rect width="528" height="396" style="fill: transparent" />
+                                </svg>
+                                <div class="hero-figure-box hero-figure-box-01" data-rotation="45deg"></div>
+                                <div class="hero-figure-box hero-figure-box-02" data-rotation="-45deg"></div>
+                                <div class="hero-figure-box hero-figure-box-03" data-rotation="0deg"></div>
+                                <div class="hero-figure-box hero-figure-box-04" data-rotation="-135deg"></div>
+                                <div class="hero-figure-box hero-figure-box-05"></div>
+                                <div class="hero-figure-box hero-figure-box-06"></div>
+                                <div class="hero-figure-box hero-figure-box-07"></div>
+                                <div class="hero-figure-box hero-figure-box-08" data-rotation="-22deg"></div>
+                                <div class="hero-figure-box hero-figure-box-09" data-rotation="-52deg"></div>
+                                <div class="hero-figure-box hero-figure-box-10" data-rotation="-50deg"></div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
                 <section class="cta section">
                     <div class="container">
                         <div class="cta-inner section-inner br-12">

--- a/public/views/login.html
+++ b/public/views/login.html
@@ -96,6 +96,7 @@
                     <div class="container">
                         <div class="hero-inner">
                             <div class="hero-copy">
+                                <h1 class="hero-title mt-0">Login to your account</h1>
                                 <div id="loginForm">
                                     <br />
                                     <div class="mb-12">
@@ -125,7 +126,7 @@
                                         </button>
                                     </div>
                                 </div>
-                                <!-- Join Room Section hidden -->
+                                <!-- Join Room Section -->
                                 <div id="joinRoomForm" class="mb-12">
                                     <div class="hero-copy reveal-from-bottom">
                                         <h1 class="hero-title mt-0">


### PR DESCRIPTION
## Summary
- add hero banner to landing page
- highlight login page with hero title

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acb50866b4832bbf51cce0b32c1370