### PR TITLE
Disable share room popup by default

### DIFF
--- a/app/src/config.js
+++ b/app/src/config.js
@@ -43,4 +43,8 @@ config.ui.brand = {
   }
 };
 
+config.ui.buttons = config.ui.buttons || {};
+config.ui.buttons.popup = config.ui.buttons.popup || {};
+config.ui.buttons.popup.shareRoomPopup = false;
+
 module.exports = config;


### PR DESCRIPTION
## Summary
- disable Share Room popup on room creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1bdfa3f7c832b96aada459d449882