### PR TITLE
feat: add PWA manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,18 @@
+{
+    "name": "MiroTalk SFU",
+    "short_name": "MiroTalk",
+    "start_url": "/",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "theme_color": "#ffffff",
+    "icons": [
+        { "src": "/images/icons/icon-72x72.png", "sizes": "72x72", "type": "image/png" },
+        { "src": "/images/icons/icon-96x96.png", "sizes": "96x96", "type": "image/png" },
+        { "src": "/images/icons/icon-128x128.png", "sizes": "128x128", "type": "image/png" },
+        { "src": "/images/icons/icon-144x144.png", "sizes": "144x144", "type": "image/png" },
+        { "src": "/images/icons/icon-152x152.png", "sizes": "152x152", "type": "image/png" },
+        { "src": "/images/icons/icon-192x192.png", "sizes": "192x192", "type": "image/png" },
+        { "src": "/images/icons/icon-384x384.png", "sizes": "384x384", "type": "image/png" },
+        { "src": "/images/icons/icon-512x512.png", "sizes": "512x512", "type": "image/png" }
+    ]
+}

--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -7,6 +7,9 @@
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#ffffff" />
+
         <!-- Meta Information -->
 
         <meta charset="utf-8" />

--- a/public/views/landing.html
+++ b/public/views/landing.html
@@ -7,6 +7,9 @@
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#ffffff" />
+
         <!-- Meta Information -->
 
         <meta charset="utf-8" />
@@ -45,7 +48,7 @@
         <div class="body-wrap">
             <main>
                 <section class="hero">
-                 <!--    <div class="container">
+                    <!--    <div class="container">
                         <div class="hero-inner">
                             <div class="hero-copy reveal-from-bottom">
                                 <h1 id="newRoomTitle" class="hero-title mt-0">
@@ -78,15 +81,13 @@
                 <section class="cta section">
                     <div class="container">
                         <div class="cta-inner section-inner br-12">
-                            <h3 id="joinDescription" class="section-title mt-0">
-                                Введите секретный-код комнаты.
-                            </h3>
+                            <h3 id="joinDescription" class="section-title mt-0">Введите секретный-код комнаты.</h3>
                             <div>
                                 <div class="mb-24">
                                     <label for="roomName"></label>
                                     <div class="form-group-desktop">
                                         <input id="roomName" class="form-input" type="text" maxlength="32" value="" />
-<!--                                         <button
+                                        <!--                                         <button
                                             id="genRoomButton"
                                             class="button button-primary br-6 mr-8 mb-8 fas fa-arrows-rotate"
                                         ></button> -->


### PR DESCRIPTION
## Summary
- add web app manifest referencing existing icons
- link manifest and theme color in landing and room pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1c728aebc832ba4969d10dae48906