### PR TITLE
Align VPN downloads page with site styling

### DIFF
--- a/public/views/Vpns.html
+++ b/public/views/Vpns.html
@@ -1,65 +1,317 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-  <meta charset="UTF-8">
-  <title>Скачать</title>
-  <style>
-    body {
-      font-family: sans-serif;
-      background-color: #0b1e63; /* тёмно-синий насыщенный фон */
-      margin: 0;
-      padding: 0;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      min-height: 100vh;
-    }
-    .card {
-      background: #f6f6ff;
-      max-width: 600px;
-      width: 90%;
-      padding: 2rem;
-      border-radius: 16px;
-      box-shadow: 0 8px 20px rgba(0,0,0,0.3);
-      text-align: center;
-    }
-    h1 {
-      color: #222;
-      margin-bottom: 1.5rem;
-    }
-    ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
-    li {
-      margin: 0.8rem 0;
-    }
-    a {
-      color: #0b1e63;
-      font-weight: bold;
-      text-decoration: none;
-      padding: 0.5rem 1rem;
-      border-radius: 8px;
-      transition: background 0.3s, color 0.3s;
-      display: inline-block;
-    }
-    a:hover {
-      background: #0b1e63;
-      color: #fff;
-    }
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h2>Выберите систему:</h2>
-    <ul>
-      <li><a href="https://itunes.apple.com/app/outline-app/id1356177741" target="_blank">iOS (App Store)</a></li>
-      <li><a href="https://itunes.apple.com/app/outline-app/id1356178125" target="_blank">macOS (App Store)</a></li>
-      <li><a href="https://s3.amazonaws.com/outline-releases/client/windows/stable/Outline-Client.exe" target="_blank">Windows (.exe)</a></li>
-      <li><a href="https://play.google.com/store/apps/details?id=org.outline.android.client" target="_blank">Android (Google Play)</a></li>
-      <li><a href="https://s3.amazonaws.com/outline-releases/client/android/stable/Outline-Client.apk" target="_blank">Android (APK, прямая загрузка)</a></li>
-    </ul>
-  </div>
-</body>
+<!doctype html>
+<html lang="ru" class="no-js">
+    <head>
+        <!-- Title and Icon -->
+
+        <title id="title">Kremlevka - Outline VPN клиенты.</title>
+        <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
+        <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
+
+        <!-- Meta Information -->
+
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <meta
+            id="description"
+            name="description"
+            content="Kremlevka powered by WebRTC and mediasoup, Real-time Simple Secure Fast video calls, messaging and screen sharing capabilities in the browser."
+        />
+        <meta
+            id="keywords"
+            name="keywords"
+            content="webrtc, miro, mediasoup, mediasoup-client, self hosted, voip, sip, real-time communications, chat, messaging, meet, webrtc stun, webrtc turn, webrtc p2p, webrtc sfu, video meeting, video chat, video conference, multi video chat, multi video conference, peer to peer, p2p, sfu, rtc, alternative to, zoom, microsoft teams, google meet, jitsi, meeting"
+        />
+
+        <!-- StyleSheet -->
+
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,600" />
+        <link rel="stylesheet" type="text/css" href="../css/landing.css" />
+
+        <style>
+            .hero.hero-vpn {
+                padding-bottom: 96px;
+            }
+
+            .download-list {
+                display: grid;
+                gap: 24px;
+                margin: 32px 0 0;
+            }
+
+            .download-card {
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
+                background: rgba(36, 40, 48, 0.8);
+                border: 1px solid rgba(255, 255, 255, 0.08);
+                border-radius: 16px;
+                padding: 28px 32px;
+                box-shadow: 0 24px 64px rgba(10, 12, 18, 0.45);
+                transition: transform 0.3s ease, box-shadow 0.3s ease;
+            }
+
+            .download-card:hover {
+                transform: translateY(-6px);
+                box-shadow: 0 32px 80px rgba(12, 18, 28, 0.55);
+            }
+
+            .download-card h3 {
+                margin: 0 0 12px;
+                font-size: 20px;
+                font-weight: 600;
+                color: #ffffff;
+            }
+
+            .download-card p {
+                margin: 0 0 20px;
+                color: rgba(255, 255, 255, 0.72);
+                line-height: 1.6;
+            }
+
+            .download-card .button {
+                align-self: flex-start;
+            }
+
+            .download-note {
+                margin-top: 32px;
+                color: rgba(255, 255, 255, 0.65);
+                line-height: 1.7;
+            }
+
+            @media (max-width: 640px) {
+                .download-card {
+                    padding: 24px;
+                    text-align: center;
+                    align-items: center;
+                }
+
+                .download-card .button {
+                    width: 100%;
+                    justify-content: center;
+                }
+
+                .download-note {
+                    text-align: center;
+                }
+            }
+        </style>
+
+        <!-- Js scripts -->
+
+        <script defer src="../js/Brand.js"></script>
+        <script async src="../js/Umami.js"></script>
+
+        <script src="https://unpkg.com/animejs@3.0.1/lib/anime.min.js"></script>
+        <script src="https://unpkg.com/scrollreveal@4.0.0/dist/scrollreveal.min.js"></script>
+    </head>
+    <body class="is-boxed has-animations">
+        <div class="body-wrap">
+            <header class="site-header">
+                <div class="container">
+                    <div class="site-header-inner">
+                        <div class="brand header-brand">
+                            <h1 class="m-0">
+                                <a href="/">
+                                    <img class="header-logo-image" src="../images/logo.svg" alt="mirotalksfu-webrtc-logo" />
+                                </a>
+                            </h1>
+                        </div>
+                    </div>
+                </div>
+            </header>
+
+            <main>
+                <section class="hero hero-vpn">
+                    <div class="container">
+                        <div class="hero-inner">
+                            <div class="hero-copy">
+                                <h1 class="hero-title mt-0">Outline VPN клиенты</h1>
+                                <p class="hero-paragraph">
+                                    Выберите установщик для своей платформы, чтобы подключиться к защищённому Outline-серверу. Все ссылки ведут на официальные источники поставщика.
+                                </p>
+                                <ul class="download-list list-reset">
+                                    <li class="download-card">
+                                        <h3>iOS</h3>
+                                        <p>Скачайте приложение в App Store и импортируйте ключ доступа, чтобы подключиться к серверу.</p>
+                                        <a
+                                            class="button button-primary button-wide-mobile"
+                                            href="https://itunes.apple.com/app/outline-app/id1356177741"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            Скачать в App Store
+                                        </a>
+                                    </li>
+                                    <li class="download-card">
+                                        <h3>macOS</h3>
+                                        <p>Используйте официальный клиент Outline для macOS из App Store.</p>
+                                        <a
+                                            class="button button-primary button-wide-mobile"
+                                            href="https://itunes.apple.com/app/outline-app/id1356178125"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            Скачать для macOS
+                                        </a>
+                                    </li>
+                                    <li class="download-card">
+                                        <h3>Windows</h3>
+                                        <p>Установите десктопный клиент Outline и импортируйте конфигурацию. Файл скачивается в формате .exe.</p>
+                                        <a
+                                            class="button button-primary button-wide-mobile"
+                                            href="https://s3.amazonaws.com/outline-releases/client/windows/stable/Outline-Client.exe"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            Скачать для Windows
+                                        </a>
+                                    </li>
+                                    <li class="download-card">
+                                        <h3>Android (Google Play)</h3>
+                                        <p>Установите Outline из Google Play для автоматических обновлений и удобного управления подключениями.</p>
+                                        <a
+                                            class="button button-primary button-wide-mobile"
+                                            href="https://play.google.com/store/apps/details?id=org.outline.android.client"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            Открыть в Google Play
+                                        </a>
+                                    </li>
+                                    <li class="download-card">
+                                        <h3>Android (APK)</h3>
+                                        <p>Скачайте последнюю версию клиента напрямую в виде APK-файла и установите вручную.</p>
+                                        <a
+                                            class="button button-primary button-wide-mobile"
+                                            href="https://s3.amazonaws.com/outline-releases/client/android/stable/Outline-Client.apk"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            Скачать APK
+                                        </a>
+                                    </li>
+                                </ul>
+                                <p class="hero-paragraph download-note">
+                                    После установки откройте приложение, выберите пункт «Добавить сервер» и вставьте свой ключ доступа. Он включает адрес сервера, порт, пароль шифрования и имя соединения — вся информация импортируется автоматически.
+                                </p>
+                            </div>
+                            <div class="hero-figure anime-element">
+                                <svg class="placeholder" width="528" height="396" viewBox="0 0 528 396">
+                                    <rect width="528" height="396" style="fill: transparent" />
+                                </svg>
+                                <div class="hero-figure-box hero-figure-box-01" data-rotation="45deg"></div>
+                                <div class="hero-figure-box hero-figure-box-02" data-rotation="-45deg"></div>
+                                <div class="hero-figure-box hero-figure-box-03" data-rotation="0deg"></div>
+                                <div class="hero-figure-box hero-figure-box-04" data-rotation="-135deg"></div>
+                                <div class="hero-figure-box hero-figure-box-05"></div>
+                                <div class="hero-figure-box hero-figure-box-06"></div>
+                                <div class="hero-figure-box hero-figure-box-07"></div>
+                                <div class="hero-figure-box hero-figure-box-08" data-rotation="-22deg"></div>
+                                <div class="hero-figure-box hero-figure-box-09" data-rotation="-52deg"></div>
+                                <div class="hero-figure-box hero-figure-box-10" data-rotation="-50deg"></div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </main>
+
+            <footer id="footer" class="site-footer">
+                <div class="container">
+                    <div class="site-footer-inner">
+                        <div class="brand footer-brand">
+                            <a href="/">
+                                <img class="header-logo-image" src="../images/logo.svg" alt="Logo" />
+                            </a>
+                        </div>
+                        <ul class="footer-links list-reset">
+                            <li>
+                                <a href="/about">About</a>
+                            </li>
+                            <li>
+                                <a href="/privacy">Privacy Policy</a>
+                            </li>
+                            <li>
+                                <a href="https://sfu.mirotalk.com/api/v1/docs/">Rest API</a>
+                            </li>
+                            <li>
+                                Contact:
+                                <a target="_blank" href="https://www.linkedin.com/in/miroslav-pejic-976a07101/">Miroslav Pejic</a>
+                            </li>
+                        </ul>
+                        <ul class="footer-social-links list-reset">
+                            <li class="footer-social-icon">
+                                <a target="_blank" href="https://discord.gg/rgGYfeYW3N">
+                                    <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+                                        <title>Forum</title>
+                                        <path
+                                            d="M13.545 2.907a13.227 13.227 0 0 0-3.257-1.011.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.19 12.19 0 0 0-3.658 0 8.258 8.258 0 0 0-.412-.833.051.051 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.041.041 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032c.001.014.01.028.021.037a13.276 13.276 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019c.308-.42.582-.863.818-1.329a.05.05 0 0 0-.01-.059.051.051 0 0 0-.018-.011 8.875 8.875 0 0 1-1.248-.595.05.05 0 0 1-.02-.066.051.051 0 0 1 .015-.019c.084-.063.168-.129.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.052.052 0 0 1 .053.007c.08.066.164.132.248.195a.051.051 0 0 1-.004.085 8.254 8.254 0 0 1-1.249.594.05.05 0 0 0-.03.03.052.052 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.235 13.235 0 0 0 4.001-2.02.049.049 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.034.034 0 0 0-.02-.019Zm-8.198 7.307c-.789 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612Zm5.316 0c-.788 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.451.73 1.438 1.613 0 .888-.631 1.612-1.438 1.612Z"
+                                            fill="#0270D7"
+                                        />
+                                    </svg>
+                                </a>
+                            </li>
+                            <li class="footer-social-icon">
+                                <a target="_blank" href="https://www.facebook.com/mirotalk">
+                                    <span class="screen-reader-text">Facebook</span>
+                                    <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+                                        <path
+                                            d="M6.023 16L6 9H3V6h3V4c0-2.7 1.672-4 4.08-4 1.153 0 2.144.086 2.433.124v2.821h-1.67c-1.31 0-1.563.623-1.563 1.536V6H13l-1 3H9.28v7H6.023z"
+                                            fill="#0270D7"
+                                        />
+                                    </svg>
+                                </a>
+                            </li>
+                            <li class="footer-social-icon">
+                                <a target="_blank" href="https://www.youtube.com/watch?v=_IVn2aINYww">
+                                    <svg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                        <path
+                                            d="M21.582,6.186c-0.23-0.86-0.908-1.538-1.768-1.768C18.254,4,12,4,12,4S5.746,4,4.186,4.418 c-0.86,0.23-1.538,0.908-1.768,1.768C2,7.746,2,12,2,12s0,4.254,0.418,5.814c0.23,0.86,0.908,1.538,1.768,1.768 C5.746,20,12,20,12,20s6.254,0,7.814-0.418c0.861-0.23,1.538-0.908,1.768-1.768C22,16.254,22,12,22,12S22,7.746,21.582,6.186z M10,15.464V8.536L16,12L10,15.464z"
+                                            fill="#0270D7"
+                                        />
+                                    </svg>
+                                </a>
+                            </li>
+                            <li class="footer-social-icon">
+                                <a target="_blank" href="mailto:miroslav.pejic.85@gmail.com">
+                                    <span class="screen-reader-text">Google</span>
+                                    <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+                                        <path
+                                            d="M7.9 7v2.4H12c-.2 1-1.2 3-4 3-2.4 0-4.3-2-4.3-4.4 0-2.4 2-4.4 4.3-4.4 1.4 0 2.3.6 2.8 1.1l1.9-1.8C11.5 1.7 9.9 1 8 1 4.1 1 1 4.1 1 8s3.1 7 7 7c4 0 6.7-2.8 6.7-6.8 0-.5 0-.8-.1-1.2H7.9z"
+                                            fill="#0270D7"
+                                        />
+                                    </svg>
+                                </a>
+                            </li>
+                            <li>
+                                <a
+                                    class="github-button"
+                                    href="https://github.com/sponsors/miroslavpejic85"
+                                    data-color-scheme="no-preference: light; light: light; dark: dark;"
+                                    data-icon="octicon-heart"
+                                    data-size="large"
+                                    aria-label="Sponsor @miroslavpejic85 on GitHub"
+                                >Sponsor</a>
+                            </li>
+                            <li>
+                                <a
+                                    class="github-button"
+                                    href="https://github.com/miroslavpejic85/mirotalksfu"
+                                    data-color-scheme="no-preference: light; light: light; dark: dark;"
+                                    data-size="large"
+                                    data-show-count="true"
+                                    aria-label="Star miroslavpejic85/mirotalk on GitHub"
+                                >Star</a>
+                            </li>
+                        </ul>
+                        <div class="footer-copyright">&copy; 2025 Kremlevka, all rights reserved</div>
+                    </div>
+                </div>
+            </footer>
+        </div>
+
+        <script defer src="../js/Landing.js"></script>
+        <script async defer src="https://buttons.github.io/buttons.js"></script>
+    </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle the Outline VPN download page to reuse the site-wide layout, fonts, and scripts
- present platform download links as themed cards with CTA buttons and usage guidance in Russian

## Testing
- not run (html-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c87603b5b8832baf7e18b9071e4839