### PR TITLE
Reorder pre-join layout to prioritize name entry

### DIFF
--- a/public/css/Room.css
+++ b/public/css/Room.css
@@ -117,6 +117,76 @@ body {
 
 .initComands {
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.init-controls-top {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.init-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.init-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.init-buttons button {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.init-selects {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.init-selects select {
+    margin-top: 0;
+}
+
+.init-name-input {
+    width: 100%;
+    margin: 0;
+    padding: 12px;
+    font-size: 1rem;
+    box-sizing: border-box;
+}
+
+.init-actions {
+    width: 100%;
+    display: flex;
+    justify-content: flex-start;
+    gap: 12px;
+    margin: 0;
+    padding: 0;
+}
+
+.init-actions .swal2-confirm {
+    width: 100%;
+    margin: 0;
+}
+
+.init-join-button {
+    height: 48px;
+    font-size: 1rem;
+}
+
+.init-validation-message {
+    margin: 0;
+    text-align: left;
+    padding: 0;
+    width: 100%;
 }
 
 /*---------------------------

--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -1240,6 +1240,35 @@ async function whoAreYou() {
         willOpen: () => {
             hide(loadingDiv);
         },
+        didOpen: () => {
+            const popup = Swal.getPopup();
+            const input = popup ? popup.querySelector('.swal2-input') : null;
+            const actions = popup ? popup.querySelector('.swal2-actions') : null;
+            const initCommands = initUser.querySelector('.initComands');
+            const topControls = initCommands ? initCommands.querySelector('.init-controls-top') : null;
+            const confirmButton = popup ? popup.querySelector('.swal2-confirm') : null;
+            const validationMessage = popup ? popup.querySelector('.swal2-validation-message') : null;
+
+            if (input && topControls) {
+                topControls.appendChild(input);
+                input.classList.add('init-name-input');
+            }
+
+            if (actions && topControls) {
+                topControls.appendChild(actions);
+                actions.classList.add('init-actions');
+            }
+
+            if (confirmButton) {
+                confirmButton.classList.add('init-join-button');
+            }
+
+            if (validationMessage && topControls) {
+                const referenceNode = actions && actions.parentElement === topControls ? actions : null;
+                topControls.insertBefore(validationMessage, referenceNode);
+                validationMessage.classList.add('init-validation-message');
+            }
+        },
         inputValidator: (name) => {
             if (!name) return 'Пожалуйста, введите ваше имя';
             const isEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(name);

--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -166,18 +166,25 @@
                     <span id="initErrorMessage" class="show-error"></span>
                 </div>
                 <div class="initComands">
-                    <button id="initVideoAudioRefreshButton" class="fas fa-rotate"></button>
-                    <button id="initAudioVideoButton" class="fas fa-eye"></button>
-                    <button id="initVideoButton" class="fas fa-video"></button>
-                    <button id="initAudioButton" class="fas fa-microphone"></button>
-                    <button id="initStartScreenButton" class="fas fa-desktop hidden"></button>
-                    <button id="initStopScreenButton" class="fas fa-stop-circle hidden"></button>
-                    <button id="initVideoMirrorButton" class="fas fa-arrow-right-arrow-left"></button>
-                    <button id="initVirtualBackgroundButton" class="fa-solid fa-image hidden"></button>
-                    <button id="initUsernameEmojiButton" class="fas fa-smile"></button>
-                    <select id="initVideoSelect" class="form-select text-light bg-dark"></select>
-                    <select id="initMicrophoneSelect" class="form-select text-light bg-dark"></select>
-                    <select id="initSpeakerSelect" class="form-select text-light bg-dark"></select>
+                    <div class="init-controls-top"></div>
+                    <div class="init-controls">
+                        <div class="init-buttons">
+                            <button id="initVideoAudioRefreshButton" class="fas fa-rotate"></button>
+                            <button id="initAudioVideoButton" class="fas fa-eye"></button>
+                            <button id="initVideoButton" class="fas fa-video"></button>
+                            <button id="initAudioButton" class="fas fa-microphone"></button>
+                            <button id="initStartScreenButton" class="fas fa-desktop hidden"></button>
+                            <button id="initStopScreenButton" class="fas fa-stop-circle hidden"></button>
+                            <button id="initVideoMirrorButton" class="fas fa-arrow-right-arrow-left"></button>
+                            <button id="initVirtualBackgroundButton" class="fa-solid fa-image hidden"></button>
+                            <button id="initUsernameEmojiButton" class="fas fa-smile"></button>
+                        </div>
+                        <div class="init-selects">
+                            <select id="initVideoSelect" class="form-select text-light bg-dark"></select>
+                            <select id="initMicrophoneSelect" class="form-select text-light bg-dark"></select>
+                            <select id="initSpeakerSelect" class="form-select text-light bg-dark"></select>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div id="usernameEmoji" class="usernameEmoji fadein center hidden"></div>


### PR DESCRIPTION
## Summary
- reorganized the join modal markup to provide a dedicated container above the device controls
- moved the SweetAlert input, validation message, and actions into the new container so the name field and join button appear first
- updated styling to support the new layout while keeping the device controls grouped underneath

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9b02e23c4832ba8ee06d8a7151ccc