### PR TITLE
Increase in-room button sizes on mobile

### DIFF
--- a/public/css/Room.css
+++ b/public/css/Room.css
@@ -374,8 +374,11 @@ body {
 }
 
 #control button {
-    font-size: 1rem;
-    padding: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    padding: 14px;
     background: var(--btns-bg-color);
     border-radius: 10px;
     border: none !important;
@@ -390,7 +393,7 @@ body {
 }
 
 #control button i {
-    font-size: 1.2rem;
+    font-size: 1.5rem;
 }
 
 #exitButton {
@@ -425,9 +428,13 @@ body {
 }
 
 #bottomButtons button {
-    width: 48px;
-    font-size: 1.4rem;
-    padding: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 60px;
+    height: 60px;
+    font-size: 1.6rem;
+    padding: 0;
     border-radius: 10px;
     background: var(--btns-bg-color);
     border: none !important;
@@ -440,16 +447,24 @@ body {
 }
 
 @media screen and (max-width: 500px) {
+    #control button {
+        padding: 16px;
+    }
+    #control button i {
+        font-size: 1.7rem;
+    }
     #bottomButtons button {
-        width: 42px;
-        font-size: 1rem;
+        width: 54px;
+        height: 54px;
+        font-size: 1.4rem;
     }
 }
 
 @media screen and (max-width: 360px) {
     #bottomButtons button {
-        width: 32px;
-        font-size: 0.7rem;
+        width: 48px;
+        height: 48px;
+        font-size: 1.3rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- enlarge the extra-controls button styling so icons stay centered with larger tap areas
- increase bottom action button dimensions and responsive font sizes to keep them legible on small screens

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9b17c029c832b9db507fd03f2fce8