### PR TITLE
Use ё in brand name

### DIFF
--- a/app/src/config.template.js
+++ b/app/src/config.template.js
@@ -1008,7 +1008,7 @@ module.exports = {
              * Site-wide settings including icons and page-specific content.
              */
             site: {
-                title: process.env.SITE_TITLE || 'Кремлевка',
+                title: process.env.SITE_TITLE || 'Кремлёвка',
                 icon: process.env.SITE_ICON_PATH || '../images/logo.svg',
                 appleTouchIcon: process.env.APPLE_TOUCH_ICON_PATH || '../images/logo.svg',
                 newRoomTitle: process.env.NEW_ROOM_TITLE || 'Pick name. <br />Share URL. <br />Start conference.',

--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Title and Icon -->
 
-        <title id="title">Кремлевка - шифрованная связь.</title>
+        <title id="title">Кремлёвка - шифрованная связь.</title>
         <link id="icon" rel="shortcut icon" href="../images/logo.svg" />
         <link id="appleTouchIcon" rel="apple-touch-icon" href="../images/logo.svg" />
 


### PR DESCRIPTION
## Summary
- update the default site title to use the brand spelling "Кремлёвка" with ё
- align the Room page document title with the new branded spelling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d42c56ccb8832b85da6d12f66437dd