### PR TITLE
Stop auto-filling room creation input

### DIFF
--- a/public/js/Common.js
+++ b/public/js/Common.js
@@ -175,8 +175,6 @@ if (roomName) {
         roomName.value = window.sessionStorage.roomID;
         window.sessionStorage.roomID = false;
         joinRoom();
-    } else {
-        typeWriter();
     }
 
     roomName.onkeyup = (e) => {


### PR DESCRIPTION
## Summary
- prevent the room name field from being auto-filled with a random string when no stored room ID exists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de62112944832b9d040582ecffa0c5