### PR TITLE
Clear stored room ID instead of flagging

### DIFF
--- a/public/js/Common.js
+++ b/public/js/Common.js
@@ -171,12 +171,12 @@ const roomName = document.getElementById('roomName');
 if (roomName) {
     roomName.value = '';
 
-    if (window.sessionStorage.roomID) {
-        roomName.value = window.sessionStorage.roomID;
-        window.sessionStorage.roomID = false;
+    const storedRoomId = window.sessionStorage.getItem('roomID');
+
+    if (storedRoomId && storedRoomId !== 'false') {
+        roomName.value = storedRoomId;
+        window.sessionStorage.removeItem('roomID');
         joinRoom();
-    } else {
-        typeWriter();
     }
 
     roomName.onkeyup = (e) => {


### PR DESCRIPTION
## Summary
- clear the temporary room ID from sessionStorage after using it so it is not interpreted as a truthy value on reload
- keep the room name input empty when no stored room ID exists so random text is not reinserted on refresh

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de62112944832b9d040582ecffa0c5