### PR TITLE
Hide unused init buttons and center controls

### DIFF
--- a/public/css/Room.css
+++ b/public/css/Room.css
@@ -156,6 +156,8 @@ body {
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
+    justify-content: center;
+    align-items: center;
 }
 
 .init-buttons button {
@@ -171,6 +173,11 @@ body {
 
 .init-selects select {
     margin-top: 0;
+}
+
+#initAudioVideoButton,
+#initUsernameEmojiButton {
+    display: none !important;
 }
 
 


### PR DESCRIPTION
## Summary
- hide the combined audio/video toggle and username emoji buttons on the pre-join screen
- center the initial control buttons for a more balanced layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dec7897c30832bb43b5a120558c707