### PR TITLE
Remove random room name auto-fill

### DIFF
--- a/public/js/Common.js
+++ b/public/js/Common.js
@@ -15,168 +15,17 @@ if (isStandalone && window.localStorage.lastRoom && window.location.pathname ===
 // NEW ROOM
 // ####################################################################
 
-const adjectives = [
-    'small',
-    'big',
-    'large',
-    'smelly',
-    'new',
-    'happy',
-    'shiny',
-    'old',
-    'clean',
-    'nice',
-    'bad',
-    'cool',
-    'hot',
-    'cold',
-    'warm',
-    'hungry',
-    'slow',
-    'fast',
-    'red',
-    'white',
-    'black',
-    'blue',
-    'green',
-    'basic',
-    'strong',
-    'cute',
-    'poor',
-    'nice',
-    'huge',
-    'rare',
-    'lucky',
-    'weak',
-    'tall',
-    'short',
-    'tiny',
-    'great',
-    'long',
-    'single',
-    'rich',
-    'young',
-    'dirty',
-    'fresh',
-    'brown',
-    'dark',
-    'crazy',
-    'sad',
-    'loud',
-    'brave',
-    'calm',
-    'silly',
-    'smart',
-];
-
-const nouns = [
-    'dog',
-    'bat',
-    'wrench',
-    'apple',
-    'pear',
-    'ghost',
-    'cat',
-    'wolf',
-    'squid',
-    'goat',
-    'snail',
-    'hat',
-    'sock',
-    'plum',
-    'bear',
-    'snake',
-    'turtle',
-    'horse',
-    'spoon',
-    'fork',
-    'spider',
-    'tree',
-    'chair',
-    'table',
-    'couch',
-    'towel',
-    'panda',
-    'bread',
-    'grape',
-    'cake',
-    'brick',
-    'rat',
-    'mouse',
-    'bird',
-    'oven',
-    'phone',
-    'photo',
-    'frog',
-    'bear',
-    'camel',
-    'sheep',
-    'shark',
-    'tiger',
-    'zebra',
-    'duck',
-    'eagle',
-    'fish',
-    'kitten',
-    'lobster',
-    'monkey',
-    'owl',
-    'puppy',
-    'pig',
-    'rabbit',
-    'fox',
-    'whale',
-    'beaver',
-    'gorilla',
-    'lizard',
-    'parrot',
-    'sloth',
-    'swan',
-];
-
-function getRandomNumber(length) {
-    let result = '';
-    let characters = '0123456789';
-    let charactersLength = characters.length;
-    for (let i = 0; i < length; i++) {
-        result += characters.charAt(Math.floor(Math.random() * charactersLength));
-    }
-    return result;
-}
-
-let adjective = adjectives[Math.floor(Math.random() * adjectives.length)];
-let noun = nouns[Math.floor(Math.random() * nouns.length)];
-let num = getRandomNumber(5);
-noun = noun.charAt(0).toUpperCase() + noun.substring(1);
-adjective = adjective.charAt(0).toUpperCase() + adjective.substring(1);
-
-// ####################################################################
-// TYPING EFFECT
-// ####################################################################
-
-let i = 0;
-let txt = num + adjective + noun;
-let speed = 100;
-
-function typeWriter() {
-    if (i < txt.length) {
-        roomName.value += txt.charAt(i);
-        i++;
-        setTimeout(typeWriter, speed);
-    }
-}
-
 const roomName = document.getElementById('roomName');
 
 if (roomName) {
     roomName.value = '';
 
-    if (window.sessionStorage.roomID) {
-        roomName.value = window.sessionStorage.roomID;
-        window.sessionStorage.roomID = false;
+    const storedRoomId = window.sessionStorage.getItem('roomID');
+
+    if (storedRoomId && storedRoomId !== 'false') {
+        roomName.value = storedRoomId;
+        window.sessionStorage.removeItem('roomID');
         joinRoom();
-    } else {
-        typeWriter();
     }
 
     roomName.onkeyup = (e) => {
@@ -237,10 +86,7 @@ function joinRoom() {
     const roomName = filterXSS(document.getElementById('roomName').value).trim().replace(/\s+/g, '-');
     const roomValid = isValidRoomName(roomName);
 
-    if (!roomValid) {
-        typeWriter();
-        return;
-    }
+    if (!roomValid) return;
 
     //window.location.href = '/join/' + roomName;
     window.location.href = '/join/?room=' + roomName;


### PR DESCRIPTION
## Summary
- remove the random adjective/noun generator and typing effect that previously filled the room input automatically
- stop calling the old typewriter fallback when validation fails so the field simply stays empty for manual entry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de62112944832b9d040582ecffa0c5