### PR TITLE
Hide mirror toggle button in pre-join camera setup

### DIFF
--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -174,7 +174,10 @@
                             <button id="initAudioButton" class="fas fa-microphone"></button>
                             <button id="initStartScreenButton" class="fas fa-desktop hidden"></button>
                             <button id="initStopScreenButton" class="fas fa-stop-circle hidden"></button>
-                            <button id="initVideoMirrorButton" class="fas fa-arrow-right-arrow-left"></button>
+                            <button
+                                id="initVideoMirrorButton"
+                                class="fas fa-arrow-right-arrow-left hidden"
+                            ></button>
                             <button id="initVirtualBackgroundButton" class="fa-solid fa-image hidden"></button>
                             <button id="initUsernameEmojiButton" class="fas fa-smile"></button>
                         </div>


### PR DESCRIPTION
## Summary
- hide the mirror toggle control in the camera setup pre-join dialog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deceaee978832b97f026b0e28cbc28