### PR TITLE
Disable automatic room name autofill

### DIFF
--- a/public/js/Common.js
+++ b/public/js/Common.js
@@ -1,16 +1,16 @@
 'use strict';
 
-let autoFillRoomName = true;
+let autoFillRoomName = false;
 
-if (window.MiroTalkAutoFillRoomName === false) {
-    autoFillRoomName = false;
+if (window.MiroTalkAutoFillRoomName === true) {
+    autoFillRoomName = true;
 } else {
     try {
         const brandData = window.sessionStorage.getItem('brandData');
         if (brandData) {
             const parsedBrand = JSON.parse(brandData);
-            if (parsedBrand?.app?.autoFillRoomName === false) {
-                autoFillRoomName = false;
+            if (parsedBrand?.app?.autoFillRoomName === true) {
+                autoFillRoomName = true;
             }
         }
     } catch (error) {


### PR DESCRIPTION
## Summary
- default room entry pages to leave the room name input blank
- keep support for explicitly opting back into auto-fill via global or brand configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded625f66c832bafb2117d85a1ef3e