### PR TITLE
Enable keep buttons always visible by default

### DIFF
--- a/public/js/LocalStorage.js
+++ b/public/js/LocalStorage.js
@@ -40,7 +40,7 @@ class LocalStorage {
             lobby: false, // default false
             pitch_bar: true, // volume indicator
             sounds: true, // room notify sounds
-            keep_buttons_visible: false, // Keep buttons always visible
+            keep_buttons_visible: true, // Keep buttons always visible
             keyboard_shortcuts: false, // keyboard shortcuts
             host_only_recording: false, // presenter
             rec_server: false, // The recording will be stored on the server rather than locally


### PR DESCRIPTION
## Summary
- set the default `keep_buttons_visible` SFU setting to true so controls remain visible for new sessions

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170bd10724832b80d0ae5f07515b98)