### PR TITLE
Disable service worker and ensure static assets are directly accessible

### DIFF
--- a/app/src/Server.js
+++ b/app/src/Server.js
@@ -449,6 +449,20 @@ function startServer() {
             },
         })
     );
+
+    // Ensure critical static assets stay reachable even when service workers are disabled
+    app.get('/manifest.json', (req, res) => {
+        res.sendFile(path.join(dir.public, 'manifest.json'));
+    });
+
+    app.use(
+        '/svg',
+        express.static(path.join(dir.public, 'svg'), {
+            setHeaders: (res) => {
+                res.setHeader('Content-Type', 'image/svg+xml');
+            },
+        })
+    );
     app.use(cors(corsOptions));
     app.use(compression());
     app.use(express.json({ limit: '50mb' })); // Handles JSON payloads

--- a/public/js/Common.js
+++ b/public/js/Common.js
@@ -20,7 +20,9 @@ if (window.MiroTalkAutoFillRoomName === true) {
 
 window.MiroTalkAutoFillRoomName = autoFillRoomName;
 
-if ('serviceWorker' in navigator) {
+const serviceWorkerEnabled = false; // Temporarily disabled to debug caching issues
+
+if (serviceWorkerEnabled && 'serviceWorker' in navigator) {
     window.addEventListener('load', () => {
         navigator.serviceWorker.register('/sw.js');
     });


### PR DESCRIPTION
## Summary
- temporarily disable the client-side service worker so that cached responses do not interfere with debugging
- explicitly expose `manifest.json` and SVG assets from the Express server to ensure they remain reachable via direct URLs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dbc9d4358832bb5f279d230899835)