### PR TITLE
Add manual media permission prompts and controls

### DIFF
--- a/public/css/Room.css
+++ b/public/css/Room.css
@@ -2002,6 +2002,66 @@ hr {
     margin-bottom: 5px;
 }
 
+.media-start-button {
+    align-items: center;
+    border-radius: 12px;
+    display: inline-flex;
+    font-weight: 700;
+    gap: 10px;
+    padding: 12px 18px;
+    text-transform: none;
+}
+
+.media-start-button i {
+    font-size: 1.2rem;
+}
+
+.media-start-button span {
+    font-size: 1rem;
+}
+
+.permission-overlay {
+    align-items: center;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    inset: 0;
+    justify-content: center;
+    padding: 20px;
+    position: fixed;
+    z-index: 15;
+}
+
+.permission-banner {
+    background: var(--body-bg);
+    border: 1px solid var(--text-color);
+    border-radius: 16px;
+    color: var(--text-color);
+    max-width: 640px;
+    padding: 24px;
+    text-align: left;
+    width: 100%;
+}
+
+.permission-banner p {
+    margin-bottom: 16px;
+}
+
+.permission-banner ul {
+    margin: 0 0 16px 20px;
+    padding: 0;
+}
+
+.permission-retry {
+    background: #2196f3;
+    border: none;
+    border-radius: 10px;
+    color: #fff;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 700;
+    padding: 10px 18px;
+}
+
 /*
 z-index:
     - 1 videoMediaContainer

--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -232,9 +232,15 @@
 
         <div id="bottomButtons" class="fadein">
             <button id="toggleExtraButton" class="hidden"><i class="fas fa-chevron-down"></i></button>
-            <button id="startAudioButton" class="hidden"><i class="fas fa-microphone-slash"></i></button>
+            <button id="startAudioButton" class="hidden media-start-button">
+                <i class="fas fa-microphone-slash"></i>
+                <span>Включить микрофон</span>
+            </button>
             <button id="stopAudioButton" class="hidden"><i class="fas fa-microphone"></i></button>
-            <button id="startVideoButton" class="hidden"><i class="fas fa-video-slash"></i></button>
+            <button id="startVideoButton" class="hidden media-start-button">
+                <i class="fas fa-video-slash"></i>
+                <span>Включить камеру</span>
+            </button>
             <button id="stopVideoButton" class="hidden"><i class="fas fa-video"></i></button>
             <button id="swapCameraButton" class="hidden"><i class="fas fa-camera-rotate"></i></button>
             <button id="startScreenButton" class="hidden"><i class="fas fa-desktop"></i></button>
@@ -244,6 +250,13 @@
             <button id="chatButton" class="hidden"><i class="fas fa-comments"></i></button>
             <button id="settingsButton" class="hidden"><i class="fas fa-cogs"></i></button>
             <button id="exitButton" class="hidden"><i class="fa-solid fa-phone-slash"></i></button>
+        </div>
+
+        <div id="permissionOverlay" class="permission-overlay hidden">
+            <div class="permission-banner">
+                <p id="permissionMessage"></p>
+                <button id="permissionRetryButton" class="permission-retry">Повторить</button>
+            </div>
         </div>
 
         <div id="emojiPickerContainer" class="roomEmoji fadein">


### PR DESCRIPTION
## Summary
- add configuration flag to disable automatic device startup and let users enter rooms without immediate media prompts
- introduce permission overlays with retry guidance for microphone and camera access errors
- update media control buttons and request flow to trigger a single media request per click with clearer labels

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693193ce787c832b93e858bf6bedec41)