### PR TITLE
Show full-size avatar when camera is off

### DIFF
--- a/public/css/VideoGrid.css
+++ b/public/css/VideoGrid.css
@@ -74,12 +74,14 @@
 }
 
 .videoAvatarImage {
-    z-index: 7;
+    z-index: 1;
     position: absolute;
     display: none;
-    width: var(--vmi-wh);
-    height: var(--vmi-wh);
-    border-radius: 50%;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 10px;
     transition: box-shadow 0.3s ease;
 }
 

--- a/public/js/RoomClient.js
+++ b/public/js/RoomClient.js
@@ -3367,7 +3367,7 @@ class RoomClient {
         }
 
         i = document.createElement('img');
-        i.className = 'videoAvatarImage center'; // pulsate
+        i.className = 'videoAvatarImage';
         i.id = peer_id + '__img';
 
         p = document.createElement('p');


### PR DESCRIPTION
## Summary
- update video-off avatar styling to fill the entire video tile
- remove the circular centering class from video-off avatars to eliminate the ring effect

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69373b947574832bb6c4b1508cc36fb4)