### PR TITLE
Keep room controls visible

### DIFF
--- a/public/js/LocalStorage.js
+++ b/public/js/LocalStorage.js
@@ -40,7 +40,7 @@ class LocalStorage {
             lobby: false, // default false
             pitch_bar: true, // volume indicator
             sounds: true, // room notify sounds
-            keep_buttons_visible: false, // Keep buttons always visible
+            keep_buttons_visible: true, // Keep buttons always visible
             keyboard_shortcuts: false, // keyboard shortcuts
             host_only_recording: false, // presenter
             rec_server: false, // The recording will be stored on the server rather than locally

--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -3982,19 +3982,10 @@ function showButtons() {
 }
 
 function checkButtonsBar() {
-    if (localStorageSettings.keep_buttons_visible) {
-        control.style.display = 'flex';
-        toggleExtraButton.innerHTML = icons.up;
-        bottomButtons.style.display = 'flex';
-        isButtonsVisible = true;
-    } else {
-        if (!isButtonsBarOver) {
-            control.style.display = 'none';
-            toggleExtraButton.innerHTML = icons.up;
-            bottomButtons.style.display = 'none';
-            isButtonsVisible = false;
-        }
-    }
+    control.style.display = 'flex';
+    toggleExtraButton.innerHTML = icons.up;
+    bottomButtons.style.display = 'flex';
+    isButtonsVisible = true;
     setTimeout(() => {
         checkButtonsBar();
     }, 10000);


### PR DESCRIPTION
## Summary
- default to keeping the control buttons visible for new sessions
- always keep the control bar displayed instead of auto-hiding

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937d6bd35b8832ba3879d3a3fd9f1f3)