### PR TITLE
Pause camera producer when stopping video

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -2361,10 +2361,10 @@ function handleButtons() {
         rc.updatePeerInfo(peer_name, socket.id, 'audio', false);
     };
     startVideoButton.onclick = () => handleStartVideoClick();
-    stopVideoButton.onclick = () => {
+    stopVideoButton.onclick = async () => {
         setVideoButtonsDisabled(true);
-        rc.closeProducer(RoomClient.mediaType.video);
-        // await rc.pauseProducer(RoomClient.mediaType.video);
+        await rc.pauseProducer(RoomClient.mediaType.video);
+        rc.updatePeerInfo(peer_name, socket.id, 'video', false);
     };
     startScreenButton.onclick = async () => {
         const moderator = rc.getModerator();


### PR DESCRIPTION
## Summary
- pause the video producer instead of closing it when stopping the camera
- update peer info to reflect paused video state when toggling the camera

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937db9aa4ec832bab1c3a935ed6ab53)