### PR TITLE
Remove duplicate video placeholder when resuming camera

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -2361,10 +2361,10 @@ function handleButtons() {
         rc.updatePeerInfo(peer_name, socket.id, 'audio', false);
     };
     startVideoButton.onclick = () => handleStartVideoClick();
-    stopVideoButton.onclick = () => {
+    stopVideoButton.onclick = async () => {
         setVideoButtonsDisabled(true);
-        rc.closeProducer(RoomClient.mediaType.video);
-        // await rc.pauseProducer(RoomClient.mediaType.video);
+        await rc.pauseProducer(RoomClient.mediaType.video);
+        rc.updatePeerInfo(peer_name, socket.id, 'video', false);
     };
     startScreenButton.onclick = async () => {
         const moderator = rc.getModerator();

--- a/public/js/RoomClient.js
+++ b/public/js/RoomClient.js
@@ -3794,6 +3794,9 @@ class RoomClient {
     setIsVideo(status) {
         if (!isBroadcastingEnabled || (isBroadcastingEnabled && isPresenter)) {
             this.peer_info.peer_video = status;
+            if (status) {
+                this.removeVideoOff(this.peer_id);
+            }
             if (!this.peer_info.peer_video) {
                 console.log('Set local video enabled: ' + status);
                 this.setVideoOff(this.peer_info, false);


### PR DESCRIPTION
## Summary
- remove video-off placeholder when video is re-enabled to avoid duplicated tiles

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937db9aa4ec832bab1c3a935ed6ab53)