### PR TITLE
Fix remote video placeholders after camera resume

### DIFF
--- a/public/js/RoomClient.js
+++ b/public/js/RoomClient.js
@@ -9685,6 +9685,9 @@ class RoomClient {
                     if (canUpdateMediaStatus) this.setPeerAudio(peer_id, status);
                     break;
                 case 'video':
+                    if (status && canUpdateMediaStatus) {
+                        this.removeVideoOff(peer_id);
+                    }
                     break;
                 case 'screen':
                     break;


### PR DESCRIPTION
## Summary
- ensure remote peers remove video placeholders when a participant turns their camera back on

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937fab92334832b9c0bf35c2c2e3767)