### PR TITLE
Add device toggles to join modal

### DIFF
--- a/public/css/Room.css
+++ b/public/css/Room.css
@@ -165,6 +165,50 @@ body {
     margin-bottom: 0;
 }
 
+.init-device-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+    align-items: center;
+}
+
+.init-device-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 12px;
+    background: #1f1f1f;
+    color: #fff;
+    border: 1px solid #333;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+    width: 100%;
+    max-width: 240px;
+}
+
+.init-device-toggle i {
+    width: 18px;
+    text-align: center;
+}
+
+.init-device-toggle span {
+    flex: 1;
+    text-align: left;
+}
+
+.init-device-toggle.active {
+    background: #104c34;
+    border-color: #2caf76;
+    color: #fff;
+}
+
+.init-device-toggle:hover {
+    background: #2a2a2a;
+    border-color: #3d3d3d;
+}
+
 .init-selects {
     display: flex;
     flex-direction: column;

--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -217,6 +217,8 @@ const microphoneSelect = getId('microphoneSelect');
 const initMicrophoneSelect = getId('initMicrophoneSelect');
 const speakerSelect = getId('speakerSelect');
 const initSpeakerSelect = getId('initSpeakerSelect');
+const initCameraToggleButton = getId('initCameraToggleButton');
+const initMicrophoneToggleButton = getId('initMicrophoneToggleButton');
 
 // ####################################################
 // VIRTUAL BACKGROUND DEFAULT IMAGES AND INIT CLASS
@@ -840,6 +842,16 @@ function setupInitButtons() {
         getId('usernameInput').value = '';
         toggleUsernameEmoji();
     };
+    if (initCameraToggleButton) {
+        initCameraToggleButton.onclick = () => {
+            handleVideo();
+        };
+    }
+    if (initMicrophoneToggleButton) {
+        initMicrophoneToggleButton.onclick = () => {
+            handleAudio();
+        };
+    }
 }
 
 // ####################################################
@@ -1255,6 +1267,7 @@ async function whoAreYou() {
         elemDisplay('initVideoSelect', false);
         elemDisplay('tabVideoDevicesBtn', false);
         initVideoContainerShow(false);
+        elemDisplay('initCameraToggleButton', false);
     }
     if (!BUTTONS.main.startAudioButton) {
         isAudioAllowed = false;
@@ -1264,6 +1277,7 @@ async function whoAreYou() {
         elemDisplay('initMicrophoneSelect', false);
         elemDisplay('initSpeakerSelect', false);
         elemDisplay('tabAudioDevicesBtn', false);
+        elemDisplay('initMicrophoneToggleButton', false);
     }
     if (!BUTTONS.main.startScreenButton) {
         hide(initStartScreenButton);
@@ -1380,6 +1394,45 @@ async function whoAreYou() {
         hide(initMicrophoneSelect);
         hide(initSpeakerSelect);
     }
+
+    syncInitDeviceControls();
+}
+
+function updateInitDeviceToggle(button, enabled, onIcon, offIcon, onLabel, offLabel) {
+    if (!button) return;
+    const icon = button.querySelector('i');
+    const label = button.querySelector('span');
+
+    if (icon) {
+        icon.className = enabled ? onIcon : offIcon;
+    }
+    if (label) {
+        label.textContent = enabled ? onLabel : offLabel;
+    }
+
+    button.classList.toggle('active', enabled);
+}
+
+function syncInitDeviceControls() {
+    updateInitDeviceToggle(
+        initCameraToggleButton,
+        isVideoAllowed,
+        'fas fa-video',
+        'fas fa-video-slash',
+        'Камера включена',
+        'Камера выключена'
+    );
+    updateInitDeviceToggle(
+        initMicrophoneToggleButton,
+        isAudioAllowed,
+        'fas fa-microphone',
+        'fas fa-microphone-slash',
+        'Микрофон включен',
+        'Микрофон выключен'
+    );
+
+    if (initVideoSelect) initVideoSelect.disabled = !isVideoAllowed;
+    if (initMicrophoneSelect) initMicrophoneSelect.disabled = !isAudioAllowed;
 }
 
 function handleAudio() {
@@ -1389,6 +1442,7 @@ function handleAudio() {
     setColor(startAudioButton, isAudioAllowed ? 'white' : 'red');
     checkInitAudio(isAudioAllowed);
     lS.setInitConfig(lS.MEDIA_TYPE.audio, isAudioAllowed);
+    syncInitDeviceControls();
 }
 
 function handleVideo() {
@@ -1398,6 +1452,8 @@ function handleVideo() {
     setColor(startVideoButton, isVideoAllowed ? 'white' : 'red');
     checkInitVideo(isVideoAllowed);
     lS.setInitConfig(lS.MEDIA_TYPE.video, isVideoAllowed);
+
+    syncInitDeviceControls();
 
     elemDisplay('imageGrid', false);
 
@@ -1431,6 +1487,8 @@ async function handleAudioVideo() {
     setColor(startVideoButton, isVideoAllowed ? 'white' : 'red');
     await checkInitVideo(isVideoAllowed);
     checkInitAudio(isAudioAllowed);
+
+    syncInitDeviceControls();
 
     elemDisplay('imageGrid', false);
 

--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -152,7 +152,7 @@
         </div>
 
         <section>
-            <div id="initUser" class="init-user hidden">
+                <div id="initUser" class="init-user hidden">
                 <div id="initVideoContainer" class="init-video-container">
                     <video
                         id="initVideo"
@@ -179,6 +179,16 @@
                             ></button>
                             <button id="initVirtualBackgroundButton" class="fa-solid fa-image hidden"></button>
                             <button id="initUsernameEmojiButton" class="fas fa-smile"></button>
+                        </div>
+                        <div class="init-device-buttons">
+                            <button id="initCameraToggleButton" class="init-device-toggle">
+                                <i class="fas fa-video-slash"></i>
+                                <span>Камера выключена</span>
+                            </button>
+                            <button id="initMicrophoneToggleButton" class="init-device-toggle">
+                                <i class="fas fa-microphone-slash"></i>
+                                <span>Микрофон выключен</span>
+                            </button>
                         </div>
                         <div class="init-selects">
                             <select id="initVideoSelect" class="form-select text-light bg-dark"></select>


### PR DESCRIPTION
## Summary
- add camera and microphone toggle buttons to the pre-join modal, defaulting to off
- synchronize device selection controls with the new toggles and disable selectors until enabled
- style the new controls to match the existing initialization layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381f35fa30832ba5b9cf53ab5c746a)