### PR TITLE
Hide pre-join controls

### DIFF
--- a/public/css/Room.css
+++ b/public/css/Room.css
@@ -119,10 +119,15 @@ body {
 }
 
 .init-user {
-    display: flex;
-    gap: 24px;
-    padding: 5px;
-    align-items: flex-start;
+    display: none;
+    gap: 0;
+    padding: 0;
+    align-items: stretch;
+}
+
+.init-user .init-video-container,
+.init-user .initComands {
+    display: none;
 }
 
 .init-video-container {
@@ -168,7 +173,7 @@ body {
 .init-device-buttons {
     display: flex;
     flex-wrap: wrap;
-    gap: 10px;
+    gap: 16px;
     justify-content: center;
     align-items: center;
 }
@@ -176,26 +181,20 @@ body {
 .init-device-toggle {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 10px 14px;
+    justify-content: center;
+    width: 64px;
+    height: 64px;
+    padding: 0;
     border-radius: 12px;
     background: #1f1f1f;
     color: #fff;
     border: 1px solid #333;
     cursor: pointer;
     transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-    width: 100%;
-    max-width: 240px;
 }
 
 .init-device-toggle i {
-    width: 18px;
-    text-align: center;
-}
-
-.init-device-toggle span {
-    flex: 1;
-    text-align: left;
+    font-size: 22px;
 }
 
 .init-device-toggle.active {

--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -1323,7 +1323,7 @@ async function whoAreYou() {
         inputAttributes: { maxlength: 254, id: 'usernameInput' },
         inputValue: default_name,
         html: initUser, // Inject HTML
-        confirmButtonText: `Присоединиться к встрече`,
+        confirmButtonText: `Войти`,
         customClass: { popup: 'init-modal-size' },
         showClass: { popup: 'animate__animated animate__fadeInDown' },
         hideClass: { popup: 'animate__animated animate__fadeOutUp' },

--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -181,13 +181,19 @@
                             <button id="initUsernameEmojiButton" class="fas fa-smile"></button>
                         </div>
                         <div class="init-device-buttons">
-                            <button id="initCameraToggleButton" class="init-device-toggle">
+                            <button
+                                id="initCameraToggleButton"
+                                class="init-device-toggle"
+                                aria-label="Переключить камеру"
+                            >
                                 <i class="fas fa-video-slash"></i>
-                                <span>Камера выключена</span>
                             </button>
-                            <button id="initMicrophoneToggleButton" class="init-device-toggle">
+                            <button
+                                id="initMicrophoneToggleButton"
+                                class="init-device-toggle"
+                                aria-label="Переключить микрофон"
+                            >
                                 <i class="fas fa-microphone-slash"></i>
-                                <span>Микрофон выключен</span>
                             </button>
                         </div>
                         <div class="init-selects">


### PR DESCRIPTION
## Summary
- hide all pre-join modal content except the default join action
- ensure camera/microphone preview and control blocks stay hidden in the modal

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69397fc47d94832b9e39b917a97398ea)