### PR TITLE
Add missing whiteboard vanishing pen control

### DIFF
--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -1343,6 +1343,7 @@
                     <input id="wbBackgroundColorEl" class="whiteboardColorPicker" type="color" value="#000000" />
                     <input id="wbDrawingColorEl" class="whiteboardColorPicker" type="color" value="#FFFFFF" />
                     <button id="whiteboardPencilBtn" class="fas fa-pencil-alt"></button>
+                    <button id="whiteboardVanishingBtn" class="fas fa-wand-magic-sparkles"></button>
                     <button id="whiteboardObjectBtn" class="fas fa-mouse-pointer"></button>
                     <button id="whiteboardUndoBtn" class="fas fa-undo"></button>
                     <button id="whiteboardRedoBtn" class="fas fa-redo"></button>


### PR DESCRIPTION
## Summary
- add the missing whiteboard vanishing pen control to the room view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b52ee9e4832b8ce164fd39a87b6c)