### PR TITLE
Keep bottom controls visible

### DIFF
--- a/public/css/Room.css
+++ b/public/css/Room.css
@@ -571,7 +571,7 @@ body {
 #bottomButtons {
     z-index: 3;
     position: fixed;
-    display: none;
+    display: flex;
     padding: 5px;
     top: var(--bottom-btns-top);
     left: var(--bottom-btns-left);

--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -4022,18 +4022,15 @@ function showButtons() {
 }
 
 function checkButtonsBar() {
+    bottomButtons.style.display = 'flex';
+    isButtonsVisible = true;
+
     if (localStorageSettings.keep_buttons_visible) {
         control.style.display = 'flex';
         toggleExtraButton.innerHTML = icons.up;
-        bottomButtons.style.display = 'flex';
-        isButtonsVisible = true;
-    } else {
-        if (!isButtonsBarOver) {
-            control.style.display = 'none';
-            toggleExtraButton.innerHTML = icons.up;
-            bottomButtons.style.display = 'none';
-            isButtonsVisible = false;
-        }
+    } else if (!isButtonsBarOver) {
+        control.style.display = 'none';
+        toggleExtraButton.innerHTML = icons.up;
     }
     setTimeout(() => {
         checkButtonsBar();


### PR DESCRIPTION
## Summary
- keep the bottom control bar displayed at all times
- prevent the auto-hide loop from hiding the bottom controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939bbe2f630832b9772525e408bce2f)