### PR TITLE
Restore controls behavior and disable auto translate

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -3556,6 +3556,11 @@ function applySyntaxHighlighting() {
 // ####################################################
 
 function loadSettingsFromLocalStorage() {
+    if (!localStorageSettings.keep_buttons_visible) {
+        localStorageSettings.keep_buttons_visible = true;
+        ls.setSettings(localStorageSettings);
+    }
+
     rc.showChatOnMessage = localStorageSettings.show_chat_on_msg;
     transcription.showOnMessage = localStorageSettings.transcript_show_on_msg;
     rc.speechInMessages = localStorageSettings.speech_in_msg;

--- a/public/js/Translate.js
+++ b/public/js/Translate.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const ENABLE_GOOGLE_TRANSLATE = false;
+
 function loadScript(src) {
     return new Promise((resolve, reject) => {
         const script = document.createElement('script');
@@ -12,6 +14,8 @@ function loadScript(src) {
 }
 
 function googleTranslateElementInit() {
+    if (!ENABLE_GOOGLE_TRANSLATE) return;
+
     new google.translate.TranslateElement(
         {
             pageLanguage: 'en',
@@ -40,6 +44,8 @@ function googleTranslateElementInit() {
 }
 
 (async function initGoogleTranslate() {
+    if (!ENABLE_GOOGLE_TRANSLATE) return;
+
     try {
         await loadScript('https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit');
     } catch (error) {


### PR DESCRIPTION
## Summary
- restore the original bottom controls visibility handling while keeping the toolbar forced visible
- ensure keep-buttons-visible preference is reset to on during load
- disable automatic Google Translate loading to prevent automatic translations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939bbe2f630832b9772525e408bce2f)