### PR TITLE
fix: camera toggle off/on (guard removeVideoProducer, prevent double DOM removal)

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -2452,11 +2452,21 @@ function handleButtons() {
         await requestCamera();
         // await rc.resumeProducer(RoomClient.mediaType.video);
     });
-    bindClick('stopVideoButton', () => {
+    bindClick('stopVideoButton', async () => {
         if (!ensureRoomClient('stop video')) return;
         setVideoButtonsDisabled(true);
-        rc.closeProducer(RoomClient.mediaType.video);
-        // await rc.pauseProducer(RoomClient.mediaType.video);
+
+        try {
+            await rc.closeProducer(RoomClient.mediaType.video);
+            // await rc.pauseProducer(RoomClient.mediaType.video);
+        } catch (error) {
+            console.error('Error stopping video producer', error);
+        } finally {
+            video = false;
+            hide(stopVideoButton);
+            BUTTONS.main.startVideoButton && show(startVideoButton);
+            setVideoButtonsDisabled(false);
+        }
     });
 
     bindClick('startScreenButton', async () => {

--- a/public/js/RoomClient.js
+++ b/public/js/RoomClient.js
@@ -2811,6 +2811,11 @@ class RoomClient {
         const producer_id = this.producerLabel.get(type);
         const producer = this.producers.get(producer_id);
 
+        if (!producer) {
+            this.producerLabel.delete(type);
+            return console.warn('Producer already closed for this type ' + type);
+        }
+
         // Stop all tracks of the producer's stream
         if (producer && producer.track) {
             try {
@@ -2830,7 +2835,12 @@ class RoomClient {
 
         this.socket.emit('producerClosed', data);
 
-        this.producers.get(producer_id).close();
+        try {
+            producer.close();
+        } catch (err) {
+            console.warn('Error closing producer:', err);
+        }
+
         this.producers.delete(producer_id);
         this.producerLabel.delete(type);
 
@@ -2846,7 +2856,7 @@ class RoomClient {
             }
 
             const video = this.getId(producer_id);
-            this.removeVideoProducer(video, event);
+            this.removeVideoProducer(video, event, producer_id);
         }
 
         if (type === mediaType.audio) {
@@ -2926,16 +2936,37 @@ class RoomClient {
     // REMOVE PRODUCER VIDEO/AUDIO
     // ####################################################
 
-    removeVideoProducer(video, event) {
+    removeVideoProducer(video, event, producer_id) {
+        if (!video) {
+            return console.warn('[removeVideoProducer] element not found', producer_id);
+        }
+
         const d = this.getId(video.id + '__video');
         const vb = this.getId(video.id + '__vb');
 
-        video.srcObject.getTracks().forEach(function (track) {
-            track.stop();
-        });
-        video.parentNode.removeChild(video);
+        if (video.srcObject) {
+            video.srcObject.getTracks().forEach(function (track) {
+                track.stop();
+            });
+        }
 
+        if (video.parentNode) {
+            video.parentNode.removeChild(video);
+        } else {
+            console.warn('[removeVideoProducer] video parent not found', producer_id);
+            return;
+        }
+
+        if (!d || !d.parentNode) {
+            console.warn('[removeVideoProducer] video wrapper not found', producer_id);
+            return;
+        }
         d.parentNode.removeChild(d);
+
+        if (!vb || !vb.parentNode) {
+            console.warn('[removeVideoProducer] vb wrapper not found', producer_id);
+            return;
+        }
         vb.parentNode.removeChild(vb);
 
         handleAspectRatio();


### PR DESCRIPTION
## Summary
- guard producer shutdown flow so repeated video closes do not throw or leave stale labels
- make video removal resilient to missing DOM nodes and stop updating the UI before the producer closes

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c2b2d7078832bac966ae079f477a0)