### PR TITLE
Hide button sidebar in room view

### DIFF
--- a/public/css/Room.css
+++ b/public/css/Room.css
@@ -511,8 +511,11 @@ body {
 #control {
     z-index: 3;
     position: absolute;
-    display: none;
+    display: none !important;
     padding: 5px;
+
+    /* Force the sidebar with shortcut buttons to stay hidden */
+    visibility: hidden;
 
     top: var(--btns-top);
     right: var(--btns-right);


### PR DESCRIPTION
## Summary
- force the room control sidebar to remain hidden
- add an explicit visibility hide to prevent it from reappearing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c30e24ce8832b81da3e65934719b2)