### PR TITLE
Set default avatar to static logo

### DIFF
--- a/public/js/RoomClient.js
+++ b/public/js/RoomClient.js
@@ -14,7 +14,7 @@
  */
 
 const cfg = {
-    useAvatarSvg: true,
+    useAvatarSvg: false,
 };
 
 const html = {


### PR DESCRIPTION
## Summary
- disable auto-generated avatars on the client
- rely on the bundled logo image as the default avatar for all users without a custom image

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ffd85c644832b8c0d5226ed9e0377)