### PR TITLE
Handle peer reconnection takeover by uuid

### DIFF
--- a/app/src/Room.js
+++ b/app/src/Room.js
@@ -549,6 +549,22 @@ module.exports = class Room {
         return peer;
     }
 
+    getPeerSocketIdByUuid(peer_uuid) {
+        for (const [socketId, peer] of this.peers.entries()) {
+            if (peer?.peer_uuid === peer_uuid) {
+                return socketId;
+            }
+        }
+        return null;
+    }
+
+    removePeerByUuid(peer_uuid) {
+        const socketId = this.getPeerSocketIdByUuid(peer_uuid);
+        if (socketId) {
+            this.removePeer(socketId);
+        }
+    }
+
     getPeers() {
         return this.peers;
     }

--- a/app/src/Server.js
+++ b/app/src/Server.js
@@ -1747,6 +1747,39 @@ function startServer() {
                 return cb('isBanned');
             }
 
+            if (!(socket.room_id in presenters)) presenters[socket.room_id] = {};
+
+            const existingSocketId = room.getPeerSocketIdByUuid(peer_uuid);
+            if (existingSocketId && existingSocketId !== socket.id) {
+                log.info('[Join] - Takeover existing peer by uuid', {
+                    room_id: room.id,
+                    peer_name: peer_name,
+                    peer_uuid: peer_uuid,
+                    oldSocketId: existingSocketId,
+                    newSocketId: socket.id,
+                });
+
+                room.removePeer(existingSocketId);
+
+                const oldSocket = io.sockets.sockets.get(existingSocketId);
+                if (oldSocket) {
+                    try {
+                        oldSocket.disconnect(true);
+                    } catch (error) {
+                        log.warn('[Join] - Error disconnecting previous peer socket', {
+                            error: error.message,
+                            oldSocketId: existingSocketId,
+                        });
+                    }
+                }
+
+                const roomPresenters = presenters[socket.room_id];
+                if (roomPresenters && roomPresenters[existingSocketId]) {
+                    roomPresenters[socket.id] = roomPresenters[existingSocketId];
+                    delete roomPresenters[existingSocketId];
+                }
+            }
+
             // Remove old peer with same socket.id before adding new one
             const existingPeer = room.getPeer(socket.id);
             if (existingPeer) {
@@ -1762,8 +1795,6 @@ function startServer() {
             const activeStreams = getRTMPActiveStreams();
 
             log.info('[Join] - current active RTMP streams', activeStreams);
-
-            if (!(socket.room_id in presenters)) presenters[socket.room_id] = {};
 
             // Set the presenters
             const presenter = {


### PR DESCRIPTION
## Summary
- add helper methods to Room for finding or removing peers by UUID
- implement UUID-based reconnection takeover in the server join flow with presenter handoff and old socket cleanup
- initialize presenter tracking before takeover to avoid stale presenter entries

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c952e460832b993a65beb796714e)