### PR TITLE
Update login placeholder text to Russian

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -1367,7 +1367,7 @@ async function whoAreYou() {
         background: swalBackground,
         title: BRAND.app?.name,
         input: 'text',
-        inputPlaceholder: 'Enter your email or name',
+        inputPlaceholder: 'Введите имя',
         inputAttributes: { maxlength: 254, id: 'usernameInput' },
         inputValue: default_name,
         html: initUser, // Inject HTML


### PR DESCRIPTION
## Summary
- change the user name prompt placeholder to Russian text "Введите имя"

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943c0f363d4832ba0868443aa584c5d)