### PR TITLE
Enable screen share button via env config

### DIFF
--- a/app/src/config.template.js
+++ b/app/src/config.template.js
@@ -1178,7 +1178,7 @@ module.exports = {
                 fullScreenButton: process.env.SHOW_FULLSCREEN_BUTTON !== 'false',
                 startAudioButton: process.env.SHOW_AUDIO_BUTTON !== 'false',
                 startVideoButton: process.env.SHOW_VIDEO_BUTTON !== 'false',
-                startScreenButton: process.env.SHOW_SCREEN_BUTTON !== 'true',
+                startScreenButton: process.env.SHOW_SCREEN_BUTTON !== 'false',
                 swapCameraButton: process.env.SHOW_SWAP_CAMERA !== 'false',
                 chatButton: process.env.SHOW_CHAT_BUTTON !== 'false',
                 pollButton: process.env.SHOW_POLL_BUTTON !== 'false',


### PR DESCRIPTION
### Motivation
- Fix the inconsistent handling of the `SHOW_SCREEN_BUTTON` environment flag so the screen sharing button can be enabled/disabled the same way as other UI buttons.

### Description
- Change the `startScreenButton` condition in `app/src/config.template.js` from `process.env.SHOW_SCREEN_BUTTON !== 'true'` to `process.env.SHOW_SCREEN_BUTTON !== 'false'` so `SHOW_SCREEN_BUTTON='true'` enables the button.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776fdc8284832b8864681efe684034)