### PR TITLE
Allow screen sharing by default

### DIFF
--- a/app/src/config.template.js
+++ b/app/src/config.template.js
@@ -1178,7 +1178,7 @@ module.exports = {
                 fullScreenButton: process.env.SHOW_FULLSCREEN_BUTTON !== 'false',
                 startAudioButton: process.env.SHOW_AUDIO_BUTTON !== 'false',
                 startVideoButton: process.env.SHOW_VIDEO_BUTTON !== 'false',
-                startScreenButton: process.env.SHOW_SCREEN_BUTTON !== 'true',
+                startScreenButton: process.env.SHOW_SCREEN_BUTTON !== 'false',
                 swapCameraButton: process.env.SHOW_SWAP_CAMERA !== 'false',
                 chatButton: process.env.SHOW_CHAT_BUTTON !== 'false',
                 pollButton: process.env.SHOW_POLL_BUTTON !== 'false',

--- a/public/views/Room.html
+++ b/public/views/Room.html
@@ -742,7 +742,6 @@
                                             id="switchEveryoneCantShareScreen"
                                             class="form-check-input"
                                             type="checkbox"
-                                            checked
                                         />
                                     </div>
                                 </td>


### PR DESCRIPTION
### Motivation
- Ensure participants can start screen sharing by default and make the UI flag handling consistent so the screen share control is available when intended.

### Description
- Update `app/src/config.template.js` to treat `SHOW_SCREEN_BUTTON` consistently with other flags by using `process.env.SHOW_SCREEN_BUTTON !== 'false'`, and default the moderator setting in `public/views/Room.html` by removing the `checked` attribute from `#switchEveryoneCantShareScreen` so the restriction is off by default.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776fdc8284832b8864681efe684034)