### PR TITLE
Fix screen-share tile cleanup and resume-screen button state

### DIFF
--- a/public/js/Room.js
+++ b/public/js/Room.js
@@ -3975,8 +3975,8 @@ function handleRoomClientEvents() {
     });
     rc.on(RoomClient.EVENTS.resumeScreen, () => {
         console.log('Room event: Client resume screen');
-        hide(stopScreenButton);
-        show(startScreenButton);
+        hide(startScreenButton);
+        show(stopScreenButton);
         hideClassElements('videoMenuBar');
         screen = true;
     });

--- a/public/js/RoomClient.js
+++ b/public/js/RoomClient.js
@@ -2999,8 +2999,11 @@ class RoomClient {
             return console.warn('[removeVideoProducer] element not found', producer_id);
         }
 
-        const d = this.getId(video.id + '__video');
-        const vb = this.getId(video.id + '__vb');
+        const peerId = video.dataset.peerId || this.peer_id;
+        const d =
+            video.closest('.Camera') ||
+            this.videoMediaContainer.querySelector(`.Camera[data-peer-id="${peerId}"]`);
+        const vb = this.getId(peerId + '__vb');
 
         if (video.srcObject) {
             video.srcObject.getTracks().forEach(function (track) {
@@ -3012,20 +3015,26 @@ class RoomClient {
             video.parentNode.removeChild(video);
         } else {
             console.warn('[removeVideoProducer] video parent not found', producer_id);
-            return;
         }
 
-        if (!d || !d.parentNode) {
+        if (d && d.parentNode) {
+            const remainingVideos = d.querySelectorAll('video');
+            if (remainingVideos.length === 0) {
+                d.parentNode.removeChild(d);
+            }
+        } else {
             console.warn('[removeVideoProducer] video wrapper not found', producer_id);
-            return;
         }
-        d.parentNode.removeChild(d);
 
-        if (!vb || !vb.parentNode) {
-            console.warn('[removeVideoProducer] vb wrapper not found', producer_id);
-            return;
+        const hasLocalVideoProducer = this.producerLabel.has(mediaType.video);
+        const hasLocalScreenProducer = this.producerLabel.has(mediaType.screen);
+        if (!hasLocalVideoProducer && !hasLocalScreenProducer) {
+            if (vb && vb.parentNode) {
+                vb.parentNode.removeChild(vb);
+            } else {
+                console.warn('[removeVideoProducer] vb wrapper not found', producer_id);
+            }
         }
-        vb.parentNode.removeChild(vb);
 
         handleAspectRatio();
 


### PR DESCRIPTION
### Motivation
- Fix leftover empty video tiles that appeared as extra users when starting/stopping screen share due to wrapper id mismatch and brittle removal logic in `removeVideoProducer`.
- Correct the wrong UI state where the `resumeScreen` event showed the start button instead of the stop button.

### Description
- Update `removeVideoProducer` in `public/js/RoomClient.js` to locate the camera card via `video.closest('.Camera')` or by `data-peer-id` using `video.dataset.peerId` as a fallback.
- Only remove the peer camera card when it contains no remaining `<video>` elements to avoid removing a card that still hosts other video elements.
- Only remove the `__vb` (video bar) element when neither local video nor screen producers remain by checking `this.producerLabel.has(mediaType.video)` and `this.producerLabel.has(mediaType.screen)`.
- Swap the `hide`/`show` calls in the `RoomClient.EVENTS.resumeScreen` handler in `public/js/Room.js` so `startScreenButton` is hidden and `stopScreenButton` is shown.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978f9d8dc38832b804de18aaabbbeb4)