### PR TITLE
Add Playwright E2E for screen-share cleanup and harden video cleanup logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
             "devDependencies": {
                 "@babel/core": "^7.28.3",
                 "@babel/preset-env": "^7.28.3",
+                "@playwright/test": "^1.49.1",
                 "babel-loader": "^10.0.0",
                 "mocha": "^11.7.1",
                 "node-fetch": "^3.3.2",
@@ -3626,6 +3627,22 @@
             "optional": true,
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.58.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+            "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.58.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@prisma/instrumentation": {
@@ -8878,6 +8895,53 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.58.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+            "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.58.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.58.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+            "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/postgres-array": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "devDependencies": {
         "@babel/core": "^7.28.3",
         "@babel/preset-env": "^7.28.3",
+        "@playwright/test": "^1.49.1",
         "babel-loader": "^10.0.0",
         "mocha": "^11.7.1",
         "node-fetch": "^3.3.2",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,25 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+    testDir: './tests/e2e',
+    timeout: 120000,
+    expect: {
+        timeout: 10000,
+    },
+    retries: 0,
+    workers: 1,
+    use: {
+        baseURL: process.env.E2E_BASE_URL || 'https://localhost:3010',
+        headless: true,
+        ignoreHTTPSErrors: true,
+        launchOptions: {
+            args: ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream'],
+        },
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { browserName: 'chromium' },
+        },
+    ],
+});

--- a/public/js/RoomClient.js
+++ b/public/js/RoomClient.js
@@ -2988,37 +2988,54 @@ class RoomClient {
     // ####################################################
 
     removeVideoProducer(video, event, producer_id) {
-        if (!video) {
-            return console.warn('[removeVideoProducer] element not found', producer_id);
+        const resolvedVideo = video || (producer_id ? this.getId(producer_id) : null);
+        const peerId = resolvedVideo?.dataset?.peerId || resolvedVideo?.getAttribute('name') || null;
+        let d = resolvedVideo?.closest('.Camera') || null;
+
+        if (!d && peerId) {
+            d =
+                this.videoMediaContainer.querySelector(`.Camera[data-peer-id="${peerId}"][data-kind="screen"]`) ||
+                this.videoMediaContainer.querySelector(`.Camera[data-peer-id="${peerId}"][data-kind="camera"]`) ||
+                null;
         }
 
-        const d = this.getId(video.id + '__video');
-        const vb = this.getId(video.id + '__vb');
-
-        if (video.srcObject) {
-            video.srcObject.getTracks().forEach(function (track) {
-                track.stop();
-            });
+        if (!d && producer_id) {
+            d = this.getId(producer_id + '__video');
         }
 
-        if (video.parentNode) {
-            video.parentNode.removeChild(video);
+        if (!d && peerId) {
+            d = this.getId(peerId + '__screen') || this.getId(peerId + '__video');
+        }
+
+        const vb = (peerId && this.getId(peerId + '__vb')) || (producer_id && this.getId(producer_id + '__vb'));
+
+        if (!resolvedVideo) {
+            console.warn('[removeVideoProducer] element not found', producer_id);
         } else {
-            console.warn('[removeVideoProducer] video parent not found', producer_id);
-            return;
+            if (resolvedVideo.srcObject) {
+                resolvedVideo.srcObject.getTracks().forEach(function (track) {
+                    track.stop();
+                });
+            }
+
+            if (resolvedVideo.parentNode) {
+                resolvedVideo.parentNode.removeChild(resolvedVideo);
+            } else {
+                console.warn('[removeVideoProducer] video parent not found', producer_id);
+            }
         }
 
         if (!d || !d.parentNode) {
             console.warn('[removeVideoProducer] video wrapper not found', producer_id);
-            return;
+        } else {
+            d.parentNode.removeChild(d);
         }
-        d.parentNode.removeChild(d);
 
         if (!vb || !vb.parentNode) {
             console.warn('[removeVideoProducer] vb wrapper not found', producer_id);
-            return;
+        } else {
+            vb.parentNode.removeChild(vb);
         }
-        vb.parentNode.removeChild(vb);
 
         handleAspectRatio();
 

--- a/tests/e2e/room.e2e.spec.js
+++ b/tests/e2e/room.e2e.spec.js
@@ -1,0 +1,207 @@
+const { test, expect } = require('@playwright/test');
+const { spawn } = require('child_process');
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+const baseURL = process.env.E2E_BASE_URL || 'https://localhost:3010';
+let serverProcess;
+let usingExistingServer = false;
+
+async function waitForServer(url, retries = 30) {
+    let lastError;
+    for (let attempt = 0; attempt < retries; attempt += 1) {
+        try {
+            const response = await fetch(url, { redirect: 'manual' });
+            if (response.ok || response.status === 302) return;
+            lastError = new Error(`Unexpected response status: ${response.status}`);
+        } catch (error) {
+            lastError = error;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    throw lastError;
+}
+
+async function openClient(browser, roomId, name) {
+    const context = await browser.newContext({
+        permissions: ['camera', 'microphone'],
+        ignoreHTTPSErrors: true,
+    });
+
+    await context.addInitScript(() => {
+        const fakeDisplayMedia = async (constraints) => {
+            const canvas = document.createElement('canvas');
+            canvas.width = 1280;
+            canvas.height = 720;
+            const ctx = canvas.getContext('2d');
+            let frame = 0;
+            setInterval(() => {
+                if (!ctx) return;
+                ctx.fillStyle = `hsl(${frame % 360}, 70%, 45%)`;
+                ctx.fillRect(0, 0, canvas.width, canvas.height);
+                ctx.fillStyle = '#ffffff';
+                ctx.font = '48px sans-serif';
+                ctx.fillText(`Screen ${frame}`, 40, 80);
+                frame += 1;
+            }, 100);
+            return canvas.captureStream(10);
+        };
+
+        if (navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
+            navigator.mediaDevices.getDisplayMedia = fakeDisplayMedia;
+        }
+        if (navigator.getDisplayMedia) {
+            navigator.getDisplayMedia = fakeDisplayMedia;
+        }
+    });
+
+    const page = await context.newPage();
+    const joinUrl = `${baseURL}/join?room=${roomId}&name=${name}&audio=1&video=1&screen=0&notify=0&chat=0`;
+
+    await page.goto(joinUrl, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => typeof rc !== 'undefined' && rc && rc.socket && rc.socket.connected);
+    await page.waitForFunction(() => typeof rc !== 'undefined' && rc && rc.peer_id);
+
+    return { context, page };
+}
+
+async function ensureVideoOn(page) {
+    const stopButton = page.locator('#stopVideoButton');
+    if (await stopButton.isVisible()) return;
+    await page.click('#startVideoButton');
+    await page.waitForSelector('#stopVideoButton', { state: 'visible' });
+}
+
+async function ensureAudioOn(page) {
+    const stopButton = page.locator('#stopAudioButton');
+    if (await stopButton.isVisible()) return;
+    await page.click('#startAudioButton');
+    await page.waitForSelector('#stopAudioButton', { state: 'visible' });
+}
+
+async function assertNoScreenTiles(page) {
+    await page.waitForFunction(() => document.querySelectorAll('.Camera[data-kind="screen"]').length === 0);
+    const result = await page.evaluate(() => {
+        const cards = Array.from(document.querySelectorAll('.Camera[data-kind="screen"]'));
+        const emptyCards = cards.filter((card) => !card.querySelector('video'));
+        return { count: cards.length, emptyCount: emptyCards.length };
+    });
+    expect(result.count).toBe(0);
+    expect(result.emptyCount).toBe(0);
+}
+
+async function waitForRemoteAudioIcon(page, peerId, shouldBeOn) {
+    await page.waitForFunction(
+        ({ remotePeerId, expectOn }) => {
+            const audioButton = document.getElementById(`${remotePeerId}__audio`);
+            if (!audioButton) return false;
+            const className = audioButton.className || '';
+            const isOff = className.includes('fa-microphone-slash');
+            return expectOn ? !isOff : isOff;
+        },
+        { remotePeerId: peerId, expectOn: shouldBeOn }
+    );
+}
+
+test.beforeAll(async () => {
+    const serverPort = new URL(baseURL).port || '3010';
+    try {
+        await waitForServer(baseURL, 1);
+        usingExistingServer = true;
+        return;
+    } catch (error) {
+        serverProcess = spawn('node', ['app/src/Server.js'], {
+            env: { ...process.env, SERVER_LISTEN_PORT: serverPort },
+            stdio: 'inherit',
+        });
+        await waitForServer(baseURL);
+    }
+});
+
+test.afterAll(async () => {
+    if (!serverProcess || usingExistingServer) return;
+    serverProcess.kill('SIGTERM');
+});
+
+test('room media controls clean up screen share tiles', async ({ browser }) => {
+    test.setTimeout(300000);
+    const roomId = `e2e-room-${Date.now()}`;
+
+    const clientA = await openClient(browser, roomId, 'UserA');
+    const clientB = await openClient(browser, roomId, 'UserB');
+
+    const pageA = clientA.page;
+    const pageB = clientB.page;
+
+    await ensureVideoOn(pageA);
+    await ensureVideoOn(pageB);
+    await ensureAudioOn(pageA);
+
+    await pageA.waitForFunction(() => document.querySelectorAll('.Camera').length >= 2);
+    await pageB.waitForFunction(() => document.querySelectorAll('.Camera').length >= 2);
+
+    const peerAId = await pageA.evaluate(() => rc.peer_id);
+    const peerBId = await pageB.evaluate(() => rc.peer_id);
+
+    await pageA.waitForFunction(
+        (peerId) => !!document.querySelector(`.Camera[data-peer-id="${peerId}"][data-kind="camera"] video`),
+        peerBId
+    );
+    await pageB.waitForFunction(
+        (peerId) => !!document.querySelector(`.Camera[data-peer-id="${peerId}"][data-kind="camera"] video`),
+        peerAId
+    );
+
+    for (let i = 0; i < 2; i += 1) {
+        await pageA.click('#stopVideoButton');
+        await pageB.waitForFunction(
+            (peerId) => !document.querySelector(`.Camera[data-peer-id="${peerId}"][data-kind="camera"] video`),
+            peerAId
+        );
+
+        await pageA.click('#startVideoButton');
+        await pageB.waitForFunction(
+            (peerId) => !!document.querySelector(`.Camera[data-peer-id="${peerId}"][data-kind="camera"] video`),
+            peerAId
+        );
+    }
+
+    for (let i = 0; i < 2; i += 1) {
+        await pageA.click('#stopAudioButton');
+        await waitForRemoteAudioIcon(pageB, peerAId, false);
+
+        await pageA.click('#startAudioButton');
+        await waitForRemoteAudioIcon(pageB, peerAId, true);
+    }
+
+    for (let i = 0; i < 1; i += 1) {
+        await pageA.click('#startScreenButton');
+        await pageB.waitForFunction((peerId) => {
+            const peerEntry = rc?.peers?.get(peerId);
+            return !!peerEntry?.peer_info?.peer_screen;
+        }, peerAId);
+
+        await pageA.click('#stopScreenButton');
+        await assertNoScreenTiles(pageA);
+        await assertNoScreenTiles(pageB);
+    }
+
+    await pageA.click('#startScreenButton');
+    await pageB.waitForFunction((peerId) => {
+        const peerEntry = rc?.peers?.get(peerId);
+        return !!peerEntry?.peer_info?.peer_screen;
+    }, peerAId);
+
+    await pageA.evaluate(() => {
+        const producerId = rc.screenProducerId;
+        const videoEl = producerId ? document.getElementById(producerId) : null;
+        const track = videoEl?.srcObject?.getVideoTracks()?.[0] || null;
+        if (track) track.stop();
+    });
+
+    await assertNoScreenTiles(pageA);
+    await assertNoScreenTiles(pageB);
+
+    await clientA.context.close();
+    await clientB.context.close();
+});


### PR DESCRIPTION
### Motivation
- Prevent “stuck”/empty video cards after stopping screen share by making video cleanup idempotent and robust when the <video> element is already gone. 
- Add automated E2E coverage to catch regressions for camera/audio/screen lifecycle and stop-via-UI / `track.onended` flows.

### Description
- Harden `removeVideoProducer` in `public/js/RoomClient.js` to tolerate missing video elements and still remove the `.Camera` wrapper and `__vb` bar using multiple fallbacks (by DOM closest, producer id, peer id and explicit selectors) and stop tracks when present.
- Add Playwright config `playwright.config.js` and an E2E test `tests/e2e/room.e2e.spec.js` that exercises: two participants, camera on/off cycles, mic on/off cycles, screen share start/stop via UI and simulated `track.onended`, and assertions that no empty screen wrappers remain after stops; the test injects a fake screen stream via a canvas for stable CI.
- Add `@playwright/test` to `devDependencies` in `package.json` and update `package-lock.json` (Playwright binaries handled via `npx playwright install` in CI).

### Testing
- Ran unit tests with `npm test` (Mocha): `63 passing` (all existing server/unit tests passed). 
- Installed Playwright runtime (`npx playwright install`) and attempted E2E runs with `npx playwright test`; server start and Playwright environment setup were automated in the test harness and additional OS deps were installed where required. 
- Playwright E2E was executed multiple times while iterating on robustness; the suite exercises camera/audio/screen flows and DOM cleanup assertions but remained flaky under CI timing constraints and environment differences — the final runs showed intermittent timeouts (the E2E spec exercised screen-share start/stop and `track.stop()` simulation, but one run ended with a test timeout). Logs and temporary test-results are available under `test-results/` for debugging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b290ff1b0832b8a1c388f773779d4)